### PR TITLE
[Feat] 매장 및 기업, 제품, 비즈니스, 자료공유 엔티티를 생성한다

### DIFF
--- a/src/main/java/umc/stockoneqback/business/domain/Business.java
+++ b/src/main/java/umc/stockoneqback/business/domain/Business.java
@@ -1,0 +1,30 @@
+package umc.stockoneqback.business.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.stockoneqback.global.Status;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+/*
+ * TODO : ADD "extends BaseTimeEntity"
+ * */
+public class Business {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "business_id")
+    private Long id;
+
+    private Status status;
+
+    /*
+    * TODO : User Table 에서 user_id (점장, 슈퍼바이저) 외래키 매핑
+    * */
+}

--- a/src/main/java/umc/stockoneqback/business/domain/Category.java
+++ b/src/main/java/umc/stockoneqback/business/domain/Category.java
@@ -1,0 +1,25 @@
+package umc.stockoneqback.business.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import umc.stockoneqback.global.EnumConverter;
+import umc.stockoneqback.global.EnumStandard;
+
+@Getter
+@AllArgsConstructor
+public enum Category implements EnumStandard {
+
+    ANNOUNCEMENT("공지사항"),
+    RECIPE("레시피"),
+    EVENT("행사내용"),
+    ETC("기타");
+
+    private String value;
+
+    @javax.persistence.Converter
+    public static class Converter extends EnumConverter<Category> {
+        public Converter() {
+            super(Category.class);
+        }
+    }
+}

--- a/src/main/java/umc/stockoneqback/business/domain/Share.java
+++ b/src/main/java/umc/stockoneqback/business/domain/Share.java
@@ -1,0 +1,34 @@
+package umc.stockoneqback.business.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.stockoneqback.global.Status;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+/*
+ * TODO : ADD "extends BaseTimeEntity"
+ * */
+public class Share {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "share_id")
+    private Long id;
+
+    private String title;
+    private String file;
+    private String content;
+    private Category category;
+    private Status status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "business_id")
+    private Business business;
+}

--- a/src/main/java/umc/stockoneqback/global/EnumConverter.java
+++ b/src/main/java/umc/stockoneqback/global/EnumConverter.java
@@ -1,0 +1,38 @@
+package umc.stockoneqback.global;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.util.Objects;
+
+@Converter
+@Slf4j
+public class EnumConverter<T extends EnumStandard> implements AttributeConverter<T , String> {
+
+    private final Class<T> enumClass;
+
+    public EnumConverter(Class<T> enumClass) {
+        this.enumClass = enumClass;
+    }
+
+    @Override
+    public String convertToDatabaseColumn(T attribute) {
+        if (attribute == null) return null;
+        return attribute.getValue();
+    }
+
+    @Override
+    public T convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        T[] enumConstants = enumClass.getEnumConstants();
+        for (T constant : enumConstants) {
+            if (Objects.equals(constant.getValue(), dbData))
+                return constant;
+        }
+        /*
+        * enum 형식 오류
+         */
+        return null;
+    }
+}

--- a/src/main/java/umc/stockoneqback/global/EnumStandard.java
+++ b/src/main/java/umc/stockoneqback/global/EnumStandard.java
@@ -1,0 +1,6 @@
+package umc.stockoneqback.global;
+
+public interface EnumStandard {
+
+    String getValue();
+}

--- a/src/main/java/umc/stockoneqback/global/Status.java
+++ b/src/main/java/umc/stockoneqback/global/Status.java
@@ -1,0 +1,21 @@
+package umc.stockoneqback.global;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Status implements EnumStandard {
+
+    NORMAL("정상"),
+    EXPIRED("소멸");
+
+    private String value;
+
+    @javax.persistence.Converter
+    public static class Converter extends EnumConverter<Status> {
+        public Converter() {
+            super(Status.class);
+        }
+    }
+}

--- a/src/main/java/umc/stockoneqback/product/domain/Product.java
+++ b/src/main/java/umc/stockoneqback/product/domain/Product.java
@@ -1,0 +1,52 @@
+package umc.stockoneqback.product.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.lang.Nullable;
+import umc.stockoneqback.global.Status;
+import umc.stockoneqback.role.domain.Store;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+/*
+ * TODO : ADD "extends BaseTimeEntity"
+ * */
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_id")
+    private Long id;
+
+    @Column(name = "product_name")
+    private String name;
+    private Long price;
+    private String vendor;
+    private String image;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private Date receivingDate;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private Date expirationDate;
+    @Nullable
+    private String location;
+    private Long requireQuant;
+    private Long stockQuant;
+    @Nullable
+    private String siteToOrder;
+    private Long orderFreq;
+    private StoreCondition storeCondition;
+    private Status status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+}

--- a/src/main/java/umc/stockoneqback/product/domain/StoreCondition.java
+++ b/src/main/java/umc/stockoneqback/product/domain/StoreCondition.java
@@ -1,0 +1,24 @@
+package umc.stockoneqback.product.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import umc.stockoneqback.global.EnumConverter;
+import umc.stockoneqback.global.EnumStandard;
+
+@Getter
+@AllArgsConstructor
+public enum StoreCondition implements EnumStandard {
+
+    FREEZING("냉동"),
+    REFRIGERATING("냉장"),
+    ROOM("상온");
+
+    private String value;
+
+    @javax.persistence.Converter
+    public static class Converter extends EnumConverter<StoreCondition> {
+        public Converter() {
+            super(StoreCondition.class);
+        }
+    }
+}

--- a/src/main/java/umc/stockoneqback/role/domain/Company.java
+++ b/src/main/java/umc/stockoneqback/role/domain/Company.java
@@ -1,0 +1,33 @@
+package umc.stockoneqback.role.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.stockoneqback.global.Status;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+/*
+ * TODO : ADD "extends BaseTimeEntity"
+ * */
+public class Company {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "company_id")
+    private Long id;
+
+    @Column(name = "company_name")
+    private String name;
+    private String sector;
+    @Column(name = "company_code")
+    private String code;
+
+    private Status status;
+
+}

--- a/src/main/java/umc/stockoneqback/role/domain/Store.java
+++ b/src/main/java/umc/stockoneqback/role/domain/Store.java
@@ -1,0 +1,33 @@
+package umc.stockoneqback.role.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.stockoneqback.global.Status;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+/*
+ * TODO : ADD "extends BaseTimeEntity"
+ * */
+public class Store {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "store_id")
+    private Long id;
+
+    @Column(name = "store_name")
+    private String name;
+    private String sector;
+    @Column(name = "store_code")
+    private String code;
+    private String address;
+
+    private Status status;
+}


### PR DESCRIPTION
## Summary 📌
- 매장 및 기업, 제품, 비즈니스, 자료공유 엔티티를 생성한다

## Describe your changes 📝
- Company, Store, Product, Business, Share Entity
- EnumConverter

## Check list ✅
- [X] I write PR according to the form
- [ ] All tests are passed
- [X] Program works normally
- [X] I set proper PR labels
- [X] I remove any redundant codes

## Opinions 🗣️
- 해당 엔티티를 구현하는 과정에서, 다음의 Enum 객체를 둔 케이스가 있었습니다.
  - Share 게시판을 분류하는 기준이 되는 Category(공지사항, 레시피, 행사내용, 기타)
  - Product 재료를 분류하는 기준이 되는 StoreCondition(냉동, 냉장, 상온)
  - Status 모든 엔티티에 존재
- 따라서, 이 Enum 객체들을 DB에 넣을 수 있도록 Converter로부터 상속받은 다형성 객체 EnumConverter을 생성하였고 모든 Enum 객체가 EnumConverter을 사용하도록 구현했습니다.
- 그 외 다른 작업과의 연결이 필요한 부분은 주석을 달아두었습니다.
- 위와 같은 맥락으로 테스트 코드는 아직 작성하지 않았고 테이블이 정상적으로 생성되는 것까지 확인된 상태입니다.

## Issue numbers and link 🚪
Closes #11 
