### PR TITLE
파일 업로드/다운로드 api를 구현한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     // Amazon S3 (NCP Object Storage)
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.450'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.232'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' // add
 
     // JWT

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     // Amazon S3 (NCP Object Storage)
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.450'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' // add
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
@@ -52,6 +53,9 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // validation (add)
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/stockoneqback/file/config/S3Config.java
+++ b/src/main/java/umc/stockoneqback/file/config/S3Config.java
@@ -1,0 +1,33 @@
+package umc.stockoneqback.file.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/umc/stockoneqback/file/controller/FileController.java
+++ b/src/main/java/umc/stockoneqback/file/controller/FileController.java
@@ -2,14 +2,13 @@ package umc.stockoneqback.file.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.stockoneqback.file.dto.UploadRequest;
 import umc.stockoneqback.file.service.FileService;
 
 import javax.validation.Valid;
+
+import java.io.IOException;
 
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
@@ -27,5 +26,11 @@ public class FileController {
                 : fileService.uploadShareFiles(request.file());
 
         return ResponseEntity.ok(uploadFileLink);
+    }
+
+    // download
+    @GetMapping(value = "/download")
+    public ResponseEntity<byte[]> download(String fileUrl) throws IOException {
+        return fileService.download(fileUrl);
     }
 }

--- a/src/main/java/umc/stockoneqback/file/controller/FileController.java
+++ b/src/main/java/umc/stockoneqback/file/controller/FileController.java
@@ -1,0 +1,31 @@
+package umc.stockoneqback.file.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.stockoneqback.file.dto.UploadRequest;
+import umc.stockoneqback.file.service.FileService;
+
+import javax.validation.Valid;
+
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class FileController {
+    private final FileService fileService;
+
+    // upload
+    @PostMapping(value = "/upload", consumes = MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<String> upload(@ModelAttribute @Valid UploadRequest request) {
+        String uploadFileLink = request.dir().equals("board")
+                ? fileService.uploadBoardFiles(request.file())
+                : fileService.uploadShareFiles(request.file());
+
+        return ResponseEntity.ok(uploadFileLink);
+    }
+}

--- a/src/main/java/umc/stockoneqback/file/dto/UploadRequest.java
+++ b/src/main/java/umc/stockoneqback/file/dto/UploadRequest.java
@@ -1,0 +1,12 @@
+package umc.stockoneqback.file.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+import umc.stockoneqback.file.utils.validation.ValidateDir;
+
+public record UploadRequest(
+        @ValidateDir
+        String dir,
+
+        MultipartFile file
+) {
+}

--- a/src/main/java/umc/stockoneqback/file/service/FileService.java
+++ b/src/main/java/umc/stockoneqback/file/service/FileService.java
@@ -1,0 +1,80 @@
+package umc.stockoneqback.file.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import umc.stockoneqback.file.utils.exception.FileErrorCode;
+import umc.stockoneqback.global.exception.ApplicationException;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FileService {
+    private static final String BOARD = "board";
+    private static final String SHARE = "share";
+
+    private final AmazonS3 amazonS3; // aws s3 client
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    // 게시글 작성 시 첨부파일 업로드
+    public String uploadBoardFiles(MultipartFile file) {
+        validateFileExists(file);
+        return uploadFile(BOARD, file);
+    }
+
+    // 자료 공유 첨부파일 업로드
+    public String uploadShareFiles(MultipartFile file) {
+        validateFileExists(file);
+        return uploadFile(SHARE, file);
+    }
+
+    // 파일 존재 여부 검증
+    private void validateFileExists(MultipartFile file) {
+        if (file == null) {
+            throw ApplicationException.type(FileErrorCode.EMPTY_FILE);
+        }
+    }
+
+    // upload to S3
+    private String uploadFile(String dir, MultipartFile file) {
+        String filePath = createFilePath(dir, file.getOriginalFilename());
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(file.getContentType());
+        objectMetadata.setContentLength(file.getSize());
+
+        try {
+            amazonS3.putObject(
+                    new PutObjectRequest(bucket, filePath, file.getInputStream(), objectMetadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead)
+            );
+        } catch (IOException e) {
+            log.error("S3 파일 업로드 실패: {}", e.getMessage());
+            throw ApplicationException.type(FileErrorCode.S3_UPLOAD_FAILED);
+        }
+
+        return amazonS3.getUrl(bucket, filePath).toString();
+    }
+
+    // uuid 사용하여 fileKey(파일명) 생성
+    private String createFilePath(String dir, String originalFileName) {
+        String fileKey = UUID.randomUUID() + "_" + originalFileName;
+
+        return switch (dir) {
+            case BOARD -> String.format("board/%s", fileKey);
+            case SHARE -> String.format("share/%s", fileKey);
+            default -> throw ApplicationException.type(FileErrorCode.INVALID_DIR);
+        };
+    }
+}

--- a/src/main/java/umc/stockoneqback/file/utils/exception/FileErrorCode.java
+++ b/src/main/java/umc/stockoneqback/file/utils/exception/FileErrorCode.java
@@ -1,0 +1,19 @@
+package umc.stockoneqback.file.utils.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import umc.stockoneqback.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum FileErrorCode implements ErrorCode {
+    EMPTY_FILE(HttpStatus.BAD_REQUEST, "UPLOAD_001", "전송된 파일이 없습니다."),
+    S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "UPLOAD_002", "파일 업로드에 실패했습니다."),
+    INVALID_DIR(HttpStatus.BAD_REQUEST, "UPLOAD_003", "유효하지 않은 경로입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/umc/stockoneqback/file/utils/validation/S3DirValidator.java
+++ b/src/main/java/umc/stockoneqback/file/utils/validation/S3DirValidator.java
@@ -1,0 +1,14 @@
+package umc.stockoneqback.file.utils.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.List;
+
+public class S3DirValidator implements ConstraintValidator<ValidateDir, String> {
+    private static final List<String> VALID_DIR = List.of("board", "share");
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return VALID_DIR.contains(value);
+    }
+}

--- a/src/main/java/umc/stockoneqback/file/utils/validation/ValidateDir.java
+++ b/src/main/java/umc/stockoneqback/file/utils/validation/ValidateDir.java
@@ -1,0 +1,17 @@
+package umc.stockoneqback.file.utils.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = S3DirValidator.class)
+public @interface ValidateDir {
+    String message() default "올바르지 않은 경로입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
## Summary 📌
파일 업로드/다운로드 api를 구현한다

## Describe your changes 📝
- build.gradle: aws 및 validation 관련 dependcy 추가
- S3Config: aws s3 bucket 관련 설정 주입
- FileService
    - 해당 원본 파일 명에 uuid 생성하여 bucket에 업로드
    - board 첨부 파일은 /board 디렉토리에 업로드
    - share 첨부 파일은 /share 디렉토리에 업로드
    - s3에서 url을 통해 다운로드

## Check list ✅
- [x] I write PR according to the form
- [ ] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️
1. 전체 첨부 파일 관리하는 file 테이블 하나를 추가한다면 fk를 여러 개 둬야 해서 연관관계 매핑이 복잡해질 것 같은데, 첨부 파일 컬럼 있는 각 테이블마다 file 테이블을 하나씩 만들어 주는 게 더 나은 방법일까요..?
2. api 작동은 postman 통해 s3 업로드 되는 것 확인했고, 테스트 코드는 file entity 추가한 후에 올리도록 하겠습니다.
(rest docs를 처음 써봐서 좀 더 찾아봐야 할 것 같습니다 🥲)

## Issue numbers and link 🚪
Closes #{13}