### PR TITLE
[Fix] EnumConverter가 정상적으로 작동하지 않는 문제를 해결한다

### DIFF
--- a/src/main/java/umc/stockoneqback/business/domain/Business.java
+++ b/src/main/java/umc/stockoneqback/business/domain/Business.java
@@ -19,6 +19,7 @@ public class Business extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Convert(converter = Status.StatusConverter.class)
     private Status status;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/umc/stockoneqback/business/domain/Category.java
+++ b/src/main/java/umc/stockoneqback/business/domain/Category.java
@@ -16,8 +16,8 @@ public enum Category implements EnumStandard {
     private String value;
 
     @javax.persistence.Converter
-    public static class Converter extends EnumConverter<Category> {
-        public Converter() {
+    public static class CategoryConverter extends EnumConverter<Category> {
+        public CategoryConverter() {
             super(Category.class);
         }
     }

--- a/src/main/java/umc/stockoneqback/business/domain/Share.java
+++ b/src/main/java/umc/stockoneqback/business/domain/Share.java
@@ -28,8 +28,10 @@ public class Share extends BaseTimeEntity {
 
     private String content;
 
+    @Convert(converter = Category.CategoryConverter.class)
     private Category category;
 
+    @Convert(converter = Status.StatusConverter.class)
     private Status status;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/umc/stockoneqback/comment/domain/Comment.java
+++ b/src/main/java/umc/stockoneqback/comment/domain/Comment.java
@@ -29,6 +29,7 @@ public class Comment extends BaseTimeEntity {
 
     private String content;
 
+    @Convert(converter = Status.StatusConverter.class)
     private Status status;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/umc/stockoneqback/global/base/Status.java
+++ b/src/main/java/umc/stockoneqback/global/base/Status.java
@@ -14,8 +14,8 @@ public enum Status implements EnumStandard {
     private String value;
 
     @javax.persistence.Converter
-    public static class Converter extends EnumConverter<Status> {
-        public Converter() {
+    public static class StatusConverter extends EnumConverter<Status> {
+        public StatusConverter() {
             super(Status.class);
         }
     }

--- a/src/main/java/umc/stockoneqback/global/config/SecurityConfig.java
+++ b/src/main/java/umc/stockoneqback/global/config/SecurityConfig.java
@@ -18,6 +18,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .csrf().disable()
                 .authorizeRequests()
                 .antMatchers("/admin/**").hasRole("ADMIN")
                 .antMatchers("/**").permitAll();

--- a/src/main/java/umc/stockoneqback/product/domain/Product.java
+++ b/src/main/java/umc/stockoneqback/product/domain/Product.java
@@ -52,8 +52,10 @@ public class Product extends BaseTimeEntity {
 
     private Long orderFreq;
 
+    @Convert(converter = StoreCondition.StoreConditionConverter.class)
     private StoreCondition storeCondition;
 
+    @Convert(converter = Status.StatusConverter.class)
     private Status status;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/umc/stockoneqback/product/domain/StoreCondition.java
+++ b/src/main/java/umc/stockoneqback/product/domain/StoreCondition.java
@@ -15,8 +15,8 @@ public enum StoreCondition implements EnumStandard {
     private String value;
 
     @javax.persistence.Converter
-    public static class Converter extends EnumConverter<StoreCondition> {
-        public Converter() {
+    public static class StoreConditionConverter extends EnumConverter<StoreCondition> {
+        public StoreConditionConverter() {
             super(StoreCondition.class);
         }
     }

--- a/src/main/java/umc/stockoneqback/reply/domain/Reply.java
+++ b/src/main/java/umc/stockoneqback/reply/domain/Reply.java
@@ -24,6 +24,7 @@ public class Reply extends BaseTimeEntity {
 
     private String content;
 
+    @Convert(converter = Status.StatusConverter.class)
     private Status status;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/umc/stockoneqback/role/domain/company/Company.java
+++ b/src/main/java/umc/stockoneqback/role/domain/company/Company.java
@@ -30,6 +30,7 @@ public class Company extends BaseTimeEntity {
     @OneToMany(mappedBy = "company", orphanRemoval = true, cascade = CascadeType.ALL)
     private List<User> employees = new ArrayList<>();
 
+    @Convert(converter = Status.StatusConverter.class)
     private Status status;
 
     @Builder

--- a/src/main/java/umc/stockoneqback/role/domain/store/Store.java
+++ b/src/main/java/umc/stockoneqback/role/domain/store/Store.java
@@ -3,6 +3,7 @@ package umc.stockoneqback.role.domain.store;
 import lombok.*;
 import umc.stockoneqback.global.base.BaseTimeEntity;
 import umc.stockoneqback.global.base.Status;
+import umc.stockoneqback.global.enumconfig.EnumConverter;
 import umc.stockoneqback.user.domain.User;
 
 import javax.persistence.*;
@@ -34,6 +35,7 @@ public class Store extends BaseTimeEntity {
     @Embedded
     private PartTimers partTimers;
 
+    @Convert(converter = Status.StatusConverter.class)
     private Status status;
 
     @Builder

--- a/src/main/java/umc/stockoneqback/user/domain/Role.java
+++ b/src/main/java/umc/stockoneqback/user/domain/Role.java
@@ -16,8 +16,8 @@ public enum Role implements EnumStandard {
     private final String value;
 
     @javax.persistence.Converter
-    public static class Converter extends EnumConverter<Role> {
-        public Converter() {
+    public static class RoleConverter extends EnumConverter<Role> {
+        public RoleConverter() {
             super(Role.class);
         }
     }

--- a/src/main/java/umc/stockoneqback/user/domain/User.java
+++ b/src/main/java/umc/stockoneqback/user/domain/User.java
@@ -43,12 +43,14 @@ public class User extends BaseTimeEntity {
 
     private String phoneNumber;
 
+    @Convert(converter = Role.RoleConverter.class)
     private Role role;
 
     @ManyToOne
     @JoinColumn(name = "company_id", referencedColumnName = "id")
     private Company company;
 
+    @Convert(converter = Status.StatusConverter.class)
     private Status status;
 
     // 회원 탈퇴시 작성한 게시글 모두 삭제


### PR DESCRIPTION
## Summary 📌
- EnumConverter가 작동하지 않고 DB에는 Enum의 순서에 해당하는 Integer 값이 들어가는 문제를 해결한다.
## Describe your changes 📝
- 각각의 Enum 내부 Converter 클래스명을 중복되지 않도록 변경
- 모든 Entity의 각 Enum column에 누락된 @Convert 설정
## Check list ✅
- [X] I write PR according to the form
- [X] All tests are passed
- [X] Program works normally
- [X] I set proper PR labels
- [X] I remove any redundant codes

## Opinions 🗣️
- Status의 경우 순서(Integer) 값이 들어가던 현상이 고쳐져 정상적으로 EnumConverter가 작동했음을 확인했습니다.
![image](https://github.com/stockOneQ/back/assets/90232934/d3e8c147-a234-4974-bc7a-7c932d6388a2)

## Issue numbers and link 🚪
Closes #23
