### PR TITLE
[Feat] 게시글 등록/수정/삭제 API를 구현한다

### DIFF
--- a/src/main/java/umc/stockoneqback/board/controller/BoardApiController.java
+++ b/src/main/java/umc/stockoneqback/board/controller/BoardApiController.java
@@ -1,0 +1,37 @@
+package umc.stockoneqback.board.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import umc.stockoneqback.board.controller.dto.BoardRequest;
+import umc.stockoneqback.board.service.BoardService;
+
+import javax.validation.Valid;
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/boards/{writerId}")
+public class BoardApiController {
+    private final BoardService boardService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@PathVariable Long writerId,
+                                       @RequestBody @Valid BoardRequest request) {
+        Long boardId = boardService.create(writerId, request.title(), request.file(), request.content());
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{boardId}")
+    public ResponseEntity<Void> update(@PathVariable Long writerId, @PathVariable Long boardId,
+                                       @RequestBody @Valid BoardRequest request) {
+        boardService.update(writerId, boardId, request.title(), request.file(), request.content());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<Void> delete(@PathVariable Long writerId, @PathVariable Long boardId) {
+        boardService.delete(writerId, boardId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/umc/stockoneqback/board/controller/dto/BoardRequest.java
+++ b/src/main/java/umc/stockoneqback/board/controller/dto/BoardRequest.java
@@ -5,7 +5,7 @@ import javax.validation.constraints.Size;
 
 public record BoardRequest(
         @NotBlank(message = "제목 작성은 필수입니다.")
-        @Size(max = 1, message = "제목은 최소 1자 이내로 작성해주세요.")
+        @Size(min = 1, message = "제목은 최소 1자 이내로 작성해주세요.")
         @Size(max = 37, message = "제목은 37자 이내로 작성해주세요.")
         String title,
 

--- a/src/main/java/umc/stockoneqback/board/controller/dto/BoardRequest.java
+++ b/src/main/java/umc/stockoneqback/board/controller/dto/BoardRequest.java
@@ -1,0 +1,19 @@
+package umc.stockoneqback.board.controller.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+public record BoardRequest(
+        @NotBlank(message = "제목 작성은 필수입니다.")
+        @Size(max = 1, message = "제목은 최소 1자 이내로 작성해주세요.")
+        @Size(max = 37, message = "제목은 37자 이내로 작성해주세요.")
+        String title,
+
+        String file,
+
+        @NotBlank(message = "내용 작성은 필수입니다.")
+        @Size(min = 1, message = "내용은 최소 1자 이상으로 작성해주세요.")
+        @Size(max = 5000, message = "내용은 5000자 이내로 작성해주세요.")
+        String content
+) {
+}

--- a/src/main/java/umc/stockoneqback/board/domain/Board.java
+++ b/src/main/java/umc/stockoneqback/board/domain/Board.java
@@ -62,4 +62,16 @@ public class Board extends BaseTimeEntity {
     public void addComment(User writer, String image, String content) {
         commentList.add(Comment.createComment(writer, this, image, content));
     }
+
+    public void updateTitle(String updateTitle){
+        this.title = updateTitle;
+    }
+
+    public void updateFile(String updateFile){
+        this.file = updateFile;
+    }
+
+    public void updateContent(String updateContent){
+        this.content = updateContent;
+    }
 }

--- a/src/main/java/umc/stockoneqback/board/exception/BoardErrorCode.java
+++ b/src/main/java/umc/stockoneqback/board/exception/BoardErrorCode.java
@@ -1,0 +1,18 @@
+package umc.stockoneqback.board.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import umc.stockoneqback.global.base.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum BoardErrorCode implements ErrorCode {
+    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_001", "게시글 정보를 찾을 수 없습니다."),
+    USER_IS_NOT_BOARD_WRITER(HttpStatus.CONFLICT, "BOARD_002", "게시글 작성자가 아닙니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/umc/stockoneqback/board/service/BoardFindService.java
+++ b/src/main/java/umc/stockoneqback/board/service/BoardFindService.java
@@ -1,0 +1,23 @@
+package umc.stockoneqback.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.board.domain.Board;
+import umc.stockoneqback.board.domain.BoardRepository;
+import umc.stockoneqback.board.exception.BoardErrorCode;
+import umc.stockoneqback.global.base.BaseException;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BoardFindService {
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public Board findById(Long boardId){
+        return boardRepository.findById(boardId)
+                .orElseThrow(() -> BaseException.type(BoardErrorCode.BOARD_NOT_FOUND));
+    }
+}
+

--- a/src/main/java/umc/stockoneqback/board/service/BoardService.java
+++ b/src/main/java/umc/stockoneqback/board/service/BoardService.java
@@ -1,0 +1,51 @@
+package umc.stockoneqback.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.board.domain.Board;
+import umc.stockoneqback.board.domain.BoardRepository;
+import umc.stockoneqback.board.exception.BoardErrorCode;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.user.domain.User;
+import umc.stockoneqback.user.service.UserFindService;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BoardService {
+    private final UserFindService userFindService;
+    private final BoardFindService boardFindService;
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public Long create(Long writerId, String title, String file, String content){
+        User writer = userFindService.findById(writerId);
+        Board board = Board.createBoard(writer, title ,file, content);
+
+        return boardRepository.save(board).getId();
+    }
+
+    @Transactional
+    public void update(Long writerId, Long boardId, String title, String file, String content){
+        validateWriter(boardId, writerId);
+        Board board = boardFindService.findById(boardId);
+
+        board.updateTitle(title);
+        board.updateFile(file);
+        board.updateContent(content);
+    }
+
+    @Transactional
+    public void delete(Long writerId, Long boardId){
+        validateWriter(boardId, writerId);
+        boardRepository.deleteById(boardId);
+    }
+
+    private void validateWriter(Long boardId, Long writerId) {
+        Board board = boardFindService.findById(boardId);
+        if (!board.getWriter().getId().equals(writerId)) {
+            throw BaseException.type(BoardErrorCode.USER_IS_NOT_BOARD_WRITER);
+        }
+    }
+}

--- a/src/main/java/umc/stockoneqback/user/exception/UserErrorCode.java
+++ b/src/main/java/umc/stockoneqback/user/exception/UserErrorCode.java
@@ -14,6 +14,7 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_STORE_CODE(HttpStatus.BAD_REQUEST, "USER_004", "가게 코드가 맞지 않습니다."),
     INVALID_COMPANY_CODE(HttpStatus.BAD_REQUEST, "USER_005", "회사 코드가 맞지 않습니다."),
     DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "USER_006", "중복된 로그인 아이디가 존재합니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_007", "유저 정보를 찾을 수 없습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/umc/stockoneqback/user/service/UserFindService.java
+++ b/src/main/java/umc/stockoneqback/user/service/UserFindService.java
@@ -1,0 +1,22 @@
+package umc.stockoneqback.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.user.domain.User;
+import umc.stockoneqback.user.domain.UserRepository;
+import umc.stockoneqback.user.exception.UserErrorCode;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserFindService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public User findById(Long userId){
+        return userRepository.findById(userId)
+                .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
@@ -1,0 +1,261 @@
+package umc.stockoneqback.board.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import umc.stockoneqback.board.controller.dto.BoardRequest;
+import umc.stockoneqback.board.exception.BoardErrorCode;
+import umc.stockoneqback.common.ControllerTest;
+import umc.stockoneqback.global.base.BaseException;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static umc.stockoneqback.fixture.BoardFixture.BOARD_0;
+
+@DisplayName("Board [Controller Layer] -> BoardApiController 테스트")
+public class BoardApiControllerTest extends ControllerTest {
+    @Nested
+    @DisplayName("게시글 등록 API [POST /api/boards/{writerId}]")
+    class createBoard {
+        private static final String BASE_URL = "/api/boards/{writerId}";
+        private static final Long WRITER_ID = 1L;
+
+        @Test
+        @DisplayName("게시글 등록에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(1L)
+                    .when(boardService)
+                    .create(anyLong(), any(), any(), any());
+
+            // when
+            final BoardRequest request = createBoardRequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL, WRITER_ID)
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request));
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isCreated()
+                    )
+                    .andDo(
+                            document(
+                                    "UserApi/Create/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    pathParameters(
+                                            parameterWithName("writerId").description("게시글 작성자 ID(PK)")
+                                    ),
+                                    requestFields(
+                                            fieldWithPath("title").description("등록할 제목"),
+                                            fieldWithPath("file").description("등록할 파일"),
+                                            fieldWithPath("content").description("등록할 내용")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 수정 API [PATCH /api/boards/{writerId}/{boardId}]")
+    class updateBoard {
+        private static final String BASE_URL = "/api/boards/{writerId}/{boardId}";
+        private static final Long WRITER_ID = 1L;
+        private static final Long BOARD_ID = 2L;
+
+        @Test
+        @DisplayName("다른 사람의 게시글은 수정할 수 없다")
+        void throwExceptionByUserIsNotBoardWriter() throws Exception {
+            // given
+            doThrow(BaseException.type(BoardErrorCode.USER_IS_NOT_BOARD_WRITER))
+                    .when(boardService)
+                    .update(anyLong(), anyLong(), any(), any(), any());
+
+            // when
+            final BoardRequest request = createBoardRequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .patch(BASE_URL, WRITER_ID, BOARD_ID)
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request));
+
+            // then
+            final BoardErrorCode expectedError = BoardErrorCode.USER_IS_NOT_BOARD_WRITER;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isConflict(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BoardApi/Update/Failure/Case2",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    pathParameters(
+                                            parameterWithName("writerId").description("게시글 작성자 ID(PK)"),
+                                            parameterWithName("boardId").description("수정할 게시글 ID(PK)")
+                                    ),
+                                    requestFields(
+                                            fieldWithPath("title").description("수정할 제목"),
+                                            fieldWithPath("file").description("수정할 파일"),
+                                            fieldWithPath("content").description("수정할 내용")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("게시글 수정에 성공한다")
+        void success() throws Exception {
+            // given
+            doNothing()
+                    .when(boardService)
+                    .update(anyLong(), anyLong(), any(), any(), any());
+
+            // when
+            final BoardRequest request = createBoardRequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .patch(BASE_URL, WRITER_ID, BOARD_ID)
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request));
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk()
+                    )
+                    .andDo(
+                            document(
+                                    "BoardApi/Update/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    pathParameters(
+                                            parameterWithName("writerId").description("게시글 작성자 ID(PK)"),
+                                            parameterWithName("boardId").description("수정할 게시글 ID(PK)")
+                                    ),
+                                    requestFields(
+                                            fieldWithPath("title").description("수정할 제목"),
+                                            fieldWithPath("content").description("수정할 내용")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 삭제 API [DELETE /api/boards/{writerId}/{boardId}]")
+    class deleteBoard {
+        private static final String BASE_URL = "/api/boards/{writerId}/{boardId}";
+        private static final Long WRITER_ID = 1L;
+        private static final Long BOARD_ID = 2L;
+
+        @Test
+        @DisplayName("다른 사람의 게시글은 삭제할 수 없다")
+        void throwExceptionByUserIsNotBoardWriter() throws Exception {
+            // given
+            doThrow(BaseException.type(BoardErrorCode.USER_IS_NOT_BOARD_WRITER))
+                    .when(boardService)
+                    .delete(anyLong(),anyLong());
+
+            // when
+            final BoardRequest request = createBoardRequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .delete(BASE_URL, WRITER_ID, BOARD_ID)
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request));
+
+            // then
+            final BoardErrorCode expectedError = BoardErrorCode.USER_IS_NOT_BOARD_WRITER;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isConflict(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BoardApi/Delete/Failure/Case2",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    pathParameters(
+                                            parameterWithName("writerId").description("게시글 작성자 ID(PK)"),
+                                            parameterWithName("boardId").description("삭제할 게시글 ID(PK)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("게시글 삭제에 성공한다")
+        void success() throws Exception {
+            // given
+            doNothing()
+                    .when(boardService)
+                    .delete(anyLong(), anyLong());
+
+            // when
+            final BoardRequest request = createBoardRequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .delete(BASE_URL, WRITER_ID, BOARD_ID)
+                    .with(csrf())
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request));
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk()
+                    )
+                    .andDo(
+                            document(
+                                    "BoardApi/Delete/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    pathParameters(
+                                            parameterWithName("writerId").description("게시글 작성자 ID(PK)"),
+                                            parameterWithName("boardId").description("삭제할 게시글 ID(PK)")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    private BoardRequest createBoardRequest() {
+        return new BoardRequest(BOARD_0.getTitle(), BOARD_0.getFile(), BOARD_0.getContent());
+    }
+}
+

--- a/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
@@ -46,13 +46,14 @@ public class BoardApiControllerTest extends ControllerTest {
             final BoardRequest request = createBoardRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, WRITER_ID)
+                    .with(csrf())
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
             // then
             mockMvc.perform(requestBuilder)
                     .andExpectAll(
-                            status().isCreated()
+                            status().isOk()
                     )
                     .andDo(
                             document(
@@ -91,6 +92,7 @@ public class BoardApiControllerTest extends ControllerTest {
             final BoardRequest request = createBoardRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, WRITER_ID, BOARD_ID)
+                    .with(csrf())
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -108,7 +110,7 @@ public class BoardApiControllerTest extends ControllerTest {
                     )
                     .andDo(
                             document(
-                                    "BoardApi/Update/Failure/Case2",
+                                    "BoardApi/Update/Failure/Case1",
                                     preprocessRequest(prettyPrint()),
                                     preprocessResponse(prettyPrint()),
                                     pathParameters(
@@ -141,6 +143,7 @@ public class BoardApiControllerTest extends ControllerTest {
             final BoardRequest request = createBoardRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, WRITER_ID, BOARD_ID)
+                    .with(csrf())
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -160,6 +163,7 @@ public class BoardApiControllerTest extends ControllerTest {
                                     ),
                                     requestFields(
                                             fieldWithPath("title").description("수정할 제목"),
+                                            fieldWithPath("file").description("수정할 파일"),
                                             fieldWithPath("content").description("수정할 내용")
                                     )
                             )
@@ -186,6 +190,7 @@ public class BoardApiControllerTest extends ControllerTest {
             final BoardRequest request = createBoardRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, WRITER_ID, BOARD_ID)
+                    .with(csrf())
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -203,7 +208,7 @@ public class BoardApiControllerTest extends ControllerTest {
                     )
                     .andDo(
                             document(
-                                    "BoardApi/Delete/Failure/Case2",
+                                    "BoardApi/Delete/Failure/Case1",
                                     preprocessRequest(prettyPrint()),
                                     preprocessResponse(prettyPrint()),
                                     pathParameters(

--- a/src/test/java/umc/stockoneqback/board/service/BoardServiceTest.java
+++ b/src/test/java/umc/stockoneqback/board/service/BoardServiceTest.java
@@ -1,0 +1,117 @@
+package umc.stockoneqback.board.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import umc.stockoneqback.board.domain.Board;
+import umc.stockoneqback.board.exception.BoardErrorCode;
+import umc.stockoneqback.common.ServiceTest;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.user.domain.User;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static umc.stockoneqback.fixture.BoardFixture.BOARD_0;
+import static umc.stockoneqback.fixture.UserFixture.ANNE;
+import static umc.stockoneqback.fixture.UserFixture.SAEWOO;
+
+@DisplayName("Board [Service Layer] -> BoardService 테스트")
+public class BoardServiceTest extends ServiceTest {
+    @Autowired
+    private BoardService boardService;
+
+    @Autowired
+    private BoardFindService boardFindService;
+
+    private User writer;
+    private User not_writer;
+    private Board board;
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    @BeforeEach
+    void setup() {
+        writer = userRepository.save(SAEWOO.toUser());
+        not_writer = userRepository.save(ANNE.toUser());
+        board = boardRepository.save(BOARD_0.toBoard(writer));
+    }
+
+    @Test
+    @DisplayName("게시글 등록에 성공한다")
+    void success() {
+        // when
+        Long boardId = boardService.create(writer.getId(), "제목", "파일", "내용");
+
+        // then
+        Board findBoard = boardRepository.findById(boardId).orElseThrow();
+        assertAll(
+                () -> assertThat(findBoard.getWriter().getId()).isEqualTo(writer.getId()),
+                () -> assertThat(findBoard.getTitle()).isEqualTo("제목"),
+                () -> assertThat(findBoard.getFile()).isEqualTo("파일"),
+                () -> assertThat(findBoard.getContent()).isEqualTo("내용"),
+                () -> assertThat(findBoard.getCreatedDate().format(formatter)).isEqualTo(LocalDateTime.now().format(formatter)),
+                () -> assertThat(findBoard.getModifiedDate().format(formatter)).isEqualTo(LocalDateTime.now().format(formatter))
+        );
+    }
+
+    @Nested
+    @DisplayName("게시글 수정")
+    class update {
+        @Test
+        @DisplayName("다른 사람의 게시글은 수정할 수 없다")
+        void throwExceptionByUserNotBoardWriter() {
+            // when - then
+            assertThatThrownBy(() -> boardService.update(not_writer.getId(),board.getId(), "제목2", "파일2", "내용2"))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(BoardErrorCode.USER_IS_NOT_BOARD_WRITER.getMessage());
+        }
+
+        @Test
+        @DisplayName("게시글 수정에 성공한다")
+        void success() {
+            // given
+            boardService.update(writer.getId(), board.getId(), "제목2", "파일2","내용2");
+
+            // when
+            Board findBoard = boardFindService.findById(board.getId());
+
+            // then
+            assertAll(
+                    () -> assertThat(findBoard.getTitle()).isEqualTo("제목2"),
+                    () -> assertThat(findBoard.getFile()).isEqualTo("파일2"),
+                    () -> assertThat(findBoard.getContent()).isEqualTo("내용2"),
+                    () -> assertThat(findBoard.getModifiedDate().format(formatter)).isEqualTo(LocalDateTime.now().format(formatter))
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 삭제")
+    class delete {
+        @Test
+        @DisplayName("다른 사람의 게시글은 삭제할 수 없다")
+        void throwExceptionByUserNotBoardWriter() {
+            // when - then
+            assertThatThrownBy(() -> boardService.delete(not_writer.getId(),board.getId()))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(BoardErrorCode.USER_IS_NOT_BOARD_WRITER.getMessage());
+        }
+
+        @Test
+        @DisplayName("게시글 삭제에 성공한다")
+        void success() {
+            // given
+            boardService.delete(writer.getId(), board.getId());
+
+            // when - then
+            assertThatThrownBy(() -> boardFindService.findById(board.getId()))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(BoardErrorCode.BOARD_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/src/test/java/umc/stockoneqback/common/ControllerTest.java
+++ b/src/test/java/umc/stockoneqback/common/ControllerTest.java
@@ -8,15 +8,20 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import umc.stockoneqback.board.controller.BoardApiController;
+import umc.stockoneqback.board.service.BoardFindService;
+import umc.stockoneqback.board.service.BoardService;
 import umc.stockoneqback.global.config.SecurityConfig;
 import umc.stockoneqback.role.service.CompanyService;
 import umc.stockoneqback.role.service.StoreService;
 import umc.stockoneqback.user.controller.UserApiController;
+import umc.stockoneqback.user.service.UserFindService;
 import umc.stockoneqback.user.service.UserService;
 
 @ImportAutoConfiguration(SecurityConfig.class)
 @WebMvcTest({
-        UserApiController.class
+        UserApiController.class,
+        BoardApiController.class
 })
 @AutoConfigureRestDocs
 @WithMockUser
@@ -35,4 +40,13 @@ public abstract class ControllerTest {
 
     @MockBean
     protected CompanyService companyService;
+
+    @MockBean
+    protected UserFindService userFindService;
+
+    @MockBean
+    protected BoardService boardService;
+
+    @MockBean
+    protected BoardFindService boardFindService;
 }

--- a/src/test/java/umc/stockoneqback/common/ServiceTest.java
+++ b/src/test/java/umc/stockoneqback/common/ServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.board.domain.BoardRepository;
 import umc.stockoneqback.role.domain.company.CompanyRepository;
 import umc.stockoneqback.role.domain.store.PartTimerRepository;
 import umc.stockoneqback.role.domain.store.StoreRepository;
@@ -26,6 +27,9 @@ public class ServiceTest {
 
     @Autowired
     protected PartTimerRepository partTimerRepository;
+
+    @Autowired
+    protected BoardRepository boardRepository;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## Summary 📌
게시글 등록/수정/삭제 API를 구현한다
## Describe your changes 📝
- 게시글 등록/수정/삭제 API 구현
   - BoardRequest (글자수 제한 @Size를 사용해서 작성)
   - BoardService
   - BoardFindService
   - BoardApiController
- 테스트 코드
   - BoardServiceTest
   - BoardApiControllerTest
       - 권한 인증하는 부분을 제외한 테스트 작성 
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️
apiController테스트는 권한을 인증하는 부분은 제외하고 테스트 작성 진행했습니다!
추후 인증 부분 해결되면 그에 맞춰서 테스트 수정하겠습니다
## Issue numbers and link 🚪
Closes #8 
