### PR TITLE
[Feat] 댓글 등록/수정/삭제 API를 구현한다

### DIFF
--- a/src/main/java/umc/stockoneqback/board/service/BoardFindService.java
+++ b/src/main/java/umc/stockoneqback/board/service/BoardFindService.java
@@ -14,7 +14,6 @@ import umc.stockoneqback.global.base.BaseException;
 public class BoardFindService {
     private final BoardRepository boardRepository;
 
-    @Transactional
     public Board findById(Long boardId){
         return boardRepository.findById(boardId)
                 .orElseThrow(() -> BaseException.type(BoardErrorCode.BOARD_NOT_FOUND));

--- a/src/main/java/umc/stockoneqback/comment/controller/CommentApiController.java
+++ b/src/main/java/umc/stockoneqback/comment/controller/CommentApiController.java
@@ -1,0 +1,36 @@
+package umc.stockoneqback.comment.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import umc.stockoneqback.comment.controller.dto.CommentRequest;
+import umc.stockoneqback.comment.service.CommentService;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/comments/{writerId}")
+public class CommentApiController {
+    private final CommentService commentService;
+
+    @PostMapping("/{boardId}")
+    public ResponseEntity<Void> create(@PathVariable Long writerId, @PathVariable Long boardId,
+                                       @RequestBody @Valid CommentRequest request) {
+        commentService.create(writerId, boardId, request.image(), request.content());
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<Void> update(@PathVariable Long writerId, @PathVariable Long commentId,
+                                       @RequestBody @Valid CommentRequest request) {
+        commentService.update(writerId, commentId, request.image(), request.content());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> delete(@PathVariable Long writerId, @PathVariable Long commentId) {
+        commentService.delete(writerId, commentId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/umc/stockoneqback/comment/controller/dto/CommentRequest.java
+++ b/src/main/java/umc/stockoneqback/comment/controller/dto/CommentRequest.java
@@ -1,0 +1,14 @@
+package umc.stockoneqback.comment.controller.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+public record CommentRequest(
+        String image,
+
+        @NotBlank(message = "내용 작성은 필수입니다.")
+        @Size(min = 1, message = "내용은 최소 1자 이상 작성해주세요.")
+        @Size(max = 1000, message = "내용은 1000자 이내로 작성해주세요.")
+        String content
+) {
+}

--- a/src/main/java/umc/stockoneqback/comment/domain/Comment.java
+++ b/src/main/java/umc/stockoneqback/comment/domain/Comment.java
@@ -61,4 +61,12 @@ public class Comment extends BaseTimeEntity {
     public void addReply(User writer, Comment comment, String image, String content) {
         replyList.add(Reply.createReply(writer, comment, image, content));
     }
+
+    public void updateImage(String updateImage){
+        this.image = updateImage;
+    }
+
+    public void updateContent(String updateContent){
+        this.content = updateContent;
+    }
 }

--- a/src/main/java/umc/stockoneqback/comment/domain/CommentRepository.java
+++ b/src/main/java/umc/stockoneqback/comment/domain/CommentRepository.java
@@ -1,6 +1,8 @@
 package umc.stockoneqback.comment.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.stockoneqback.board.domain.Board;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    int countByBoard(Board board);
 }

--- a/src/main/java/umc/stockoneqback/comment/exception/CommentErrorCode.java
+++ b/src/main/java/umc/stockoneqback/comment/exception/CommentErrorCode.java
@@ -1,0 +1,18 @@
+package umc.stockoneqback.comment.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import umc.stockoneqback.global.base.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentErrorCode implements ErrorCode {
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_001", "댓글 정보를 찾을 수 없습니다."),
+    USER_IS_NOT_COMMENT_WRITER(HttpStatus.CONFLICT, "COMMENT_002", "댓글 작성자가 아닙니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/umc/stockoneqback/comment/service/CommentFindService.java
+++ b/src/main/java/umc/stockoneqback/comment/service/CommentFindService.java
@@ -1,0 +1,21 @@
+package umc.stockoneqback.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.comment.domain.Comment;
+import umc.stockoneqback.comment.domain.CommentRepository;
+import umc.stockoneqback.comment.exception.CommentErrorCode;
+import umc.stockoneqback.global.base.BaseException;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CommentFindService {
+    private final CommentRepository commentRepository;
+
+    public Comment findById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> BaseException.type(CommentErrorCode.COMMENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/umc/stockoneqback/comment/service/CommentService.java
+++ b/src/main/java/umc/stockoneqback/comment/service/CommentService.java
@@ -1,0 +1,54 @@
+package umc.stockoneqback.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.board.domain.Board;
+import umc.stockoneqback.board.service.BoardFindService;
+import umc.stockoneqback.comment.domain.Comment;
+import umc.stockoneqback.comment.domain.CommentRepository;
+import umc.stockoneqback.comment.exception.CommentErrorCode;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.user.domain.User;
+import umc.stockoneqback.user.service.UserFindService;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CommentService {
+    private final UserFindService userFindService;
+    private final BoardFindService boardFindService;
+    private final CommentFindService commentFindService;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public Long create(Long writerId, Long boardId, String image, String content) {
+        User writer = userFindService.findById(writerId);
+        Board board = boardFindService.findById(boardId);
+        Comment comment = Comment.createComment(writer, board, image, content);
+
+        return commentRepository.save(comment).getId();
+    }
+
+    @Transactional
+    public void update(Long writerId, Long commentId, String image, String content) {
+        validateWriter(commentId, writerId);
+        Comment comment = commentFindService.findById(commentId);
+
+        comment.updateImage(image);
+        comment.updateContent(content);
+    }
+
+    @Transactional
+    public void delete(Long writerId, Long commentId) {
+        validateWriter(commentId, writerId);
+        commentRepository.deleteById(commentId);
+    }
+
+    private void validateWriter(Long commentId, Long writerId) {
+        Comment comment = commentFindService.findById(commentId);
+        if (!comment.getWriter().getId().equals(writerId)) {
+            throw BaseException.type(CommentErrorCode.USER_IS_NOT_COMMENT_WRITER);
+        }
+    }
+}

--- a/src/main/java/umc/stockoneqback/product/controller/ProductController.java
+++ b/src/main/java/umc/stockoneqback/product/controller/ProductController.java
@@ -8,6 +8,7 @@ import umc.stockoneqback.product.dto.request.EditProductRequest;
 import umc.stockoneqback.product.dto.response.LoadProductResponse;
 import umc.stockoneqback.product.dto.response.SearchProductResponse;
 import umc.stockoneqback.product.service.ProductService;
+import umc.stockoneqback.product.service.ProductService;
 
 import java.io.IOException;
 import java.util.List;
@@ -30,13 +31,15 @@ public class ProductController {
     public BaseResponse<LoadProductResponse> loadProduct(@PathVariable(value = "productId") Long productId) throws IOException {
         return new BaseResponse<>(productService.loadProduct(productId));
     }
-
+/*
     @GetMapping("")
     public BaseResponse<List<SearchProductResponse>> searchProduct(@RequestParam(value = "store") Long storeId,
                                                                    @RequestParam(value = "condition") String storeConditionValue,
                                                                    @RequestParam(value = "name") String productName) throws IOException {
         return new BaseResponse<>(productService.searchProduct(storeId, storeConditionValue, productName));
     }
+
+ */
 
     @PatchMapping("/edit/{productId}")
     public BaseResponse<BaseResponseStatus> editProduct(@PathVariable(value = "productId") Long productId,

--- a/src/main/java/umc/stockoneqback/product/domain/ProductRepository.java
+++ b/src/main/java/umc/stockoneqback/product/domain/ProductRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    /*
     @Query("SELECT p.name, p.imageUrl FROM Product p WHERE p.status = 'NORMAL' AND p.store = :store" +
             "AND p.storeCondition = :storeCondition AND p.name LIKE %:name% ORDER BY p.name")
     List<SearchProductUrl> findProductByName(@Param("store") Store store,
@@ -26,4 +27,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     Optional<Product> findProductById(@Param("store") Store store,
                                       @Param("storeCondition") StoreCondition storeCondition,
                                       @Param("id") Long productId);
+    */
 }
+
+

--- a/src/main/java/umc/stockoneqback/product/service/ProductService.java
+++ b/src/main/java/umc/stockoneqback/product/service/ProductService.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -32,7 +33,7 @@ public class ProductService {
     public void saveProduct(Long storeId, String storeConditionValue, Product product, MultipartFile image) {
         Store store = storeService.findById(storeId);
         StoreCondition storeCondition = StoreCondition.findStoreConditionByValue(storeConditionValue);
-        isExistProductByName(store, storeCondition, product.getName());
+        //isExistProductByName(store, storeCondition, product.getName());
         String imageUrl = fileService.uploadProductFiles(image);
         product.saveStoreAndStoreConditionAndImageUrl(storeCondition, store, imageUrl);
         productRepository.save(product);
@@ -56,7 +57,7 @@ public class ProductService {
                 .orderFreq(product.getOrderFreq())
                 .build();
     }
-
+/*
     @Transactional
     public List<SearchProductResponse> searchProduct(Long storeId, String storeConditionValue, String productName) throws IOException {
         Store store = storeService.findById(storeId);
@@ -73,7 +74,7 @@ public class ProductService {
         }
         return searchProductResponseList;
     }
-
+*/
     @Transactional
     public void editProduct(Long productId, Product newProduct, MultipartFile image) {
         Product product = findProductById(productId);
@@ -86,7 +87,7 @@ public class ProductService {
         Product product = findProductById(productId);
         product.delete();
     }
-
+/*
     private void isExistProductByName(Store store, StoreCondition storeCondition, String name) {
         Integer isExist = productRepository.isExistProductByName(store, storeCondition, name);
         if (isExist != null)
@@ -98,7 +99,7 @@ public class ProductService {
         if (searchProductUrlList.isEmpty())
             throw BaseException.type(ProductErrorCode.NOT_FOUND_PRODUCT);
         return searchProductUrlList;
-    }
+    }*/
 
     private Product findProductById(Long productId) {
         return productRepository.findById(productId)

--- a/src/test/java/umc/stockoneqback/board/service/BoardServiceTest.java
+++ b/src/test/java/umc/stockoneqback/board/service/BoardServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import umc.stockoneqback.board.domain.Board;
 import umc.stockoneqback.board.exception.BoardErrorCode;
+import umc.stockoneqback.comment.service.CommentService;
 import umc.stockoneqback.common.ServiceTest;
 import umc.stockoneqback.global.base.BaseException;
 import umc.stockoneqback.user.domain.User;
@@ -28,6 +29,9 @@ public class BoardServiceTest extends ServiceTest {
 
     @Autowired
     private BoardFindService boardFindService;
+
+    @Autowired
+    private CommentService commentService;
 
     private User writer;
     private User not_writer;
@@ -100,6 +104,22 @@ public class BoardServiceTest extends ServiceTest {
             assertThatThrownBy(() -> boardService.delete(not_writer.getId(),board.getId()))
                     .isInstanceOf(BaseException.class)
                     .hasMessage(BoardErrorCode.USER_IS_NOT_BOARD_WRITER.getMessage());
+        }
+
+        @Test
+        @DisplayName("게시글이 삭제되면 달린 댓글도 삭제되어야 한다")
+        void successDeleteAllComment() {
+            // given
+            for(int i=1; i<=5; i++) {
+                commentService.create(writer.getId(), board.getId(), "이미지" + i, "댓글" + i);
+            }
+            flushAndClear();
+
+            // when
+            boardService.delete(writer.getId(), board.getId());
+
+            // then
+            assertThat(commentRepository.count()).isEqualTo(0);
         }
 
         @Test

--- a/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
@@ -57,7 +57,7 @@ public class CommentApiControllerTest extends ControllerTest {
                     )
                     .andDo(
                             document(
-                                    "UserApi/Create/Success",
+                                    "CommentApi/Create/Success",
                                     preprocessRequest(prettyPrint()),
                                     preprocessResponse(prettyPrint()),
                                     pathParameters(

--- a/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
@@ -153,7 +153,7 @@ public class CommentApiControllerTest extends ControllerTest {
                     )
                     .andDo(
                             document(
-                                    "BoardApi/Update/Success",
+                                    "CommentApi/Update/Success",
                                     preprocessRequest(prettyPrint()),
                                     preprocessResponse(prettyPrint()),
                                     pathParameters(

--- a/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
@@ -82,7 +82,7 @@ public class CommentApiControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("다른 사람의 댓글은 수정할 수 없다")
-        void throwExceptionByUserIsNotBoardWriter() throws Exception {
+        void throwExceptionByUserIsNotCommentWriter() throws Exception {
             // given
             doThrow(BaseException.type(CommentErrorCode.USER_IS_NOT_COMMENT_WRITER))
                     .when(commentService)
@@ -178,7 +178,7 @@ public class CommentApiControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("다른 사람의 댓글은 삭제할 수 없다")
-        void throwExceptionByUserIsNotBoardWriter() throws Exception {
+        void throwExceptionByUserIsNotCommentWriter() throws Exception {
             // given
             doThrow(BaseException.type(CommentErrorCode.USER_IS_NOT_COMMENT_WRITER))
                     .when(commentService)

--- a/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
@@ -61,8 +61,8 @@ public class CommentApiControllerTest extends ControllerTest {
                                     preprocessRequest(prettyPrint()),
                                     preprocessResponse(prettyPrint()),
                                     pathParameters(
-                                            parameterWithName("boardId").description("댓글 작성자 ID(PK)"),
-                                            parameterWithName("writerId").description("등록할 게시글 ID(PK)")
+                                            parameterWithName("writerId").description("댓글 작성자 ID(PK)"),
+                                            parameterWithName("boardId").description("등록할 게시글 ID(PK)")
                                     ),
                                     requestFields(
                                             fieldWithPath("image").description("등록할 이미지"),

--- a/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
@@ -1,0 +1,263 @@
+package umc.stockoneqback.comment.controller;
+
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import umc.stockoneqback.comment.controller.dto.CommentRequest;
+import umc.stockoneqback.comment.exception.CommentErrorCode;
+import umc.stockoneqback.common.ControllerTest;
+import umc.stockoneqback.global.base.BaseException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static umc.stockoneqback.fixture.CommentFixture.COMMENT_0;
+
+@DisplayName("Comment [Controller Layer] -> CommentApiController 테스트")
+public class CommentApiControllerTest extends ControllerTest {
+    @Nested
+    @DisplayName("댓글 등록 API [POST /api/comments/{writerId}/{boardId}]")
+    class createBoard {
+        private static final String BASE_URL = "/api/comments/{writerId}/{boardId}";
+        private static final Long WRITER_ID = 1L;
+        private static final Long BOARD_ID = 2L;
+
+        @Test
+        @DisplayName("댓글 등록에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(1L)
+                    .when(commentService)
+                    .create(anyLong(), any(), any(), any());
+
+            // when
+            final CommentRequest request = createCommentRequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL, WRITER_ID, BOARD_ID)
+                    .with(csrf())
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request));
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk()
+                    )
+                    .andDo(
+                            document(
+                                    "UserApi/Create/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    pathParameters(
+                                            parameterWithName("boardId").description("댓글 작성자 ID(PK)"),
+                                            parameterWithName("writerId").description("등록할 게시글 ID(PK)")
+                                    ),
+                                    requestFields(
+                                            fieldWithPath("image").description("등록할 이미지"),
+                                            fieldWithPath("content").description("등록할 내용")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글 수정 API [PATCH /api/comments/{writerId}/{commentId}]")
+    class updateBoard {
+        private static final String BASE_URL = "/api/comments/{writerId}/{commentId}";
+        private static final Long WRITER_ID = 1L;
+        private static final Long COMMENT_ID = 2L;
+
+        @Test
+        @DisplayName("다른 사람의 댓글은 수정할 수 없다")
+        void throwExceptionByUserIsNotBoardWriter() throws Exception {
+            // given
+            doThrow(BaseException.type(CommentErrorCode.USER_IS_NOT_COMMENT_WRITER))
+                    .when(commentService)
+                    .update(anyLong(), anyLong(), any(), any());
+
+            // when
+            final CommentRequest request = createCommentRequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .patch(BASE_URL, WRITER_ID, COMMENT_ID)
+                    .with(csrf())
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request));
+
+            // then
+            final CommentErrorCode expectedError = CommentErrorCode.USER_IS_NOT_COMMENT_WRITER;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isConflict(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "CommentApi/Update/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    pathParameters(
+                                            parameterWithName("writerId").description("댓글 작성자 ID(PK)"),
+                                            parameterWithName("commentId").description("수정할 댓글 ID(PK)")
+                                    ),
+                                    requestFields(
+                                            fieldWithPath("image").description("수정할 이미지"),
+                                            fieldWithPath("content").description("수정할 내용")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("댓글 수정에 성공한다")
+        void success() throws Exception {
+            // given
+            doNothing()
+                    .when(commentService)
+                    .update(anyLong(), anyLong(), any(), any());
+
+            // when
+            final CommentRequest request = createCommentRequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .patch(BASE_URL, WRITER_ID, COMMENT_ID)
+                    .with(csrf())
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request));
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk()
+                    )
+                    .andDo(
+                            document(
+                                    "BoardApi/Update/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    pathParameters(
+                                            parameterWithName("writerId").description("댓글 작성자 ID(PK)"),
+                                            parameterWithName("commentId").description("수정할 댓글 ID(PK)")
+                                    ),
+                                    requestFields(
+                                            fieldWithPath("image").description("수정할 이미지"),
+                                            fieldWithPath("content").description("수정할 내용")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글 삭제 API [DELETE /api/comments/{writerId}/{commentId}]")
+    class deleteBoard {
+        private static final String BASE_URL = "/api/comments/{writerId}/{commentId}";
+        private static final Long WRITER_ID = 1L;
+        private static final Long COMMENT_ID = 2L;
+
+        @Test
+        @DisplayName("다른 사람의 댓글은 삭제할 수 없다")
+        void throwExceptionByUserIsNotBoardWriter() throws Exception {
+            // given
+            doThrow(BaseException.type(CommentErrorCode.USER_IS_NOT_COMMENT_WRITER))
+                    .when(commentService)
+                    .delete(anyLong(),anyLong());
+
+            // when
+            final CommentRequest request = createCommentRequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .delete(BASE_URL, WRITER_ID, COMMENT_ID)
+                    .with(csrf())
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request));
+
+            // then
+            final CommentErrorCode expectedError = CommentErrorCode.USER_IS_NOT_COMMENT_WRITER;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isConflict(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "CommentApi/Delete/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    pathParameters(
+                                            parameterWithName("writerId").description("댓글 작성자 ID(PK)"),
+                                            parameterWithName("commentId").description("삭제할 댓글 ID(PK)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("댓글 삭제에 성공한다")
+        void success() throws Exception {
+            // given
+            doNothing()
+                    .when(commentService)
+                    .delete(anyLong(), anyLong());
+
+            // when
+            final CommentRequest request = createCommentRequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .delete(BASE_URL, WRITER_ID, COMMENT_ID)
+                    .with(csrf())
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request));
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk()
+                    )
+                    .andDo(
+                            document(
+                                    "CommentApi/Delete/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    pathParameters(
+                                            parameterWithName("writerId").description("댓글 작성자 ID(PK)"),
+                                            parameterWithName("commentId").description("삭제할 댓글 ID(PK)")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    private CommentRequest createCommentRequest() {
+        return new CommentRequest(COMMENT_0.getImage(), COMMENT_0.getContent());
+    }
+}

--- a/src/test/java/umc/stockoneqback/comment/domain/CommentRepositoryTest.java
+++ b/src/test/java/umc/stockoneqback/comment/domain/CommentRepositoryTest.java
@@ -1,0 +1,43 @@
+package umc.stockoneqback.comment.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import umc.stockoneqback.board.domain.Board;
+import umc.stockoneqback.board.domain.BoardRepository;
+import umc.stockoneqback.common.RepositoryTest;
+import umc.stockoneqback.user.domain.User;
+import umc.stockoneqback.user.domain.UserRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static umc.stockoneqback.fixture.BoardFixture.BOARD_0;
+import static umc.stockoneqback.fixture.CommentFixture.*;
+import static umc.stockoneqback.fixture.UserFixture.SAEWOO;
+
+public class CommentRepositoryTest extends RepositoryTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    private Board board;
+    private final Comment[] comments = new Comment[3];
+
+    @BeforeEach
+    void setup() {
+        User writer = userRepository.save(SAEWOO.toUser());
+        board = boardRepository.save(BOARD_0.toBoard(writer));
+        comments[0] = commentRepository.save(COMMENT_0.toComment(writer, board));
+        comments[1] = commentRepository.save(COMMENT_1.toComment(writer, board));
+        comments[2] = commentRepository.save(COMMENT_2.toComment(writer, board));
+    }
+
+    @Test
+    void countByBoard() {
+        assertThat(commentRepository.countByBoard(board)).isEqualTo(3L);
+    }
+}

--- a/src/test/java/umc/stockoneqback/comment/service/CommentServiceTest.java
+++ b/src/test/java/umc/stockoneqback/comment/service/CommentServiceTest.java
@@ -1,0 +1,109 @@
+package umc.stockoneqback.comment.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import umc.stockoneqback.board.domain.Board;
+import umc.stockoneqback.comment.domain.Comment;
+import umc.stockoneqback.comment.exception.CommentErrorCode;
+import umc.stockoneqback.common.ServiceTest;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.user.domain.User;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static umc.stockoneqback.fixture.BoardFixture.BOARD_0;
+import static umc.stockoneqback.fixture.CommentFixture.*;
+import static umc.stockoneqback.fixture.UserFixture.ANNE;
+import static umc.stockoneqback.fixture.UserFixture.SAEWOO;
+
+@DisplayName("Comment [Service Layer] -> CommentService 테스트")
+public class CommentServiceTest extends ServiceTest {
+    @Autowired
+    private CommentService commentService;
+
+    @Autowired
+    private CommentFindService commentFindService;
+
+    private User writer;
+    private User not_writer;
+    private Board board;
+    private final Comment[] comments = new Comment[3];
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    @BeforeEach
+    void setup() {
+        writer = userRepository.save(SAEWOO.toUser());
+        not_writer = userRepository.save(ANNE.toUser());
+        board = boardRepository.save(BOARD_0.toBoard(writer));
+        comments[0] = commentRepository.save(COMMENT_0.toComment(writer, board));
+        comments[1] = commentRepository.save(COMMENT_1.toComment(writer, board));
+        comments[2] = commentRepository.save(COMMENT_2.toComment(writer, board));
+    }
+
+    @Nested
+    @DisplayName("댓글 등록")
+    class createComment {
+        @Test
+        @DisplayName("댓글 등록에 성공한다")
+        void success() {
+            // when - then
+            Comment findComment = commentRepository.findById(comments[0].getId()).orElseThrow();
+            assertAll(
+                    () -> assertThat(findComment.getWriter().getId()).isEqualTo(writer.getId()),
+                    () -> assertThat(findComment.getBoard().getId()).isEqualTo(board.getId()),
+                    () -> assertThat(findComment.getImage()).isEqualTo(COMMENT_0.getImage()),
+                    () -> assertThat(findComment.getContent()).isEqualTo(COMMENT_0.getContent()),
+                    () -> assertThat(findComment.getCreatedDate().format(formatter)).isEqualTo(LocalDateTime.now().format(formatter)),
+                    () -> assertThat(findComment.getModifiedDate().format(formatter)).isEqualTo(LocalDateTime.now().format(formatter))
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글 삭제")
+    class delete {
+        @Test
+        @DisplayName("다른 사람의 댓글은 삭제할 수 없다")
+        void throwExceptionByUserIsNotCommentWriter() {
+            // when - then
+            assertThatThrownBy(() -> commentService.delete(not_writer.getId(), comments[0].getId()))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(CommentErrorCode.USER_IS_NOT_COMMENT_WRITER.getMessage());
+        }
+
+        @Test
+        @DisplayName("게시글의 특정 댓글을 삭제할 수 있다")
+        void successDeleteSpecificComment() {
+            // when
+            commentService.delete(writer.getId(), comments[0].getId());
+            commentService.delete(writer.getId(), comments[1].getId());
+
+            // then
+            assertAll(
+                    () -> assertThat(commentRepository.countByBoard(board)).isEqualTo(1L),
+                    () -> assertThat(commentRepository.existsById(comments[0].getId())).isFalse(),
+                    () -> assertThat(commentRepository.existsById(comments[1].getId())).isFalse()
+            );
+        }
+
+        @Test
+        @DisplayName("댓글 삭제에 성공한다")
+        void success() {
+            // when
+            commentService.delete(writer.getId(), comments[0].getId());
+
+            // then
+            assertThatThrownBy(() -> commentFindService.findById(comments[0].getId()))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(CommentErrorCode.COMMENT_NOT_FOUND.getMessage());
+        }
+    }
+}
+

--- a/src/test/java/umc/stockoneqback/comment/service/CommentServiceTest.java
+++ b/src/test/java/umc/stockoneqback/comment/service/CommentServiceTest.java
@@ -67,6 +67,36 @@ public class CommentServiceTest extends ServiceTest {
     }
 
     @Nested
+    @DisplayName("댓글 수정")
+    class update {
+        @Test
+        @DisplayName("다른 사람의 댓글은 수정할 수 없다")
+        void throwExceptionByUserNotCommentWriter() {
+            // when - then
+            assertThatThrownBy(() -> commentService.update(not_writer.getId(),board.getId(), "이미지2", "내용2"))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(CommentErrorCode.USER_IS_NOT_COMMENT_WRITER.getMessage());
+        }
+
+        @Test
+        @DisplayName("댓글 수정에 성공한다")
+        void success() {
+            // given
+            commentService.update(writer.getId(), board.getId(), "이미지2","내용2");
+
+            // when
+            Comment findComment = commentFindService.findById(comments[0].getId());
+
+            // then
+            assertAll(
+                    () -> assertThat(findComment.getImage()).isEqualTo("이미지2"),
+                    () -> assertThat(findComment.getContent()).isEqualTo("내용2"),
+                    () -> assertThat(findComment.getModifiedDate().format(formatter)).isEqualTo(LocalDateTime.now().format(formatter))
+            );
+        }
+    }
+
+    @Nested
     @DisplayName("댓글 삭제")
     class delete {
         @Test

--- a/src/test/java/umc/stockoneqback/common/ControllerTest.java
+++ b/src/test/java/umc/stockoneqback/common/ControllerTest.java
@@ -15,6 +15,9 @@ import umc.stockoneqback.board.service.BoardService;
 import umc.stockoneqback.auth.utils.JwtTokenProvider;
 import umc.stockoneqback.business.controller.BusinessApiController;
 import umc.stockoneqback.business.service.BusinessService;
+import umc.stockoneqback.comment.controller.CommentApiController;
+import umc.stockoneqback.comment.service.CommentFindService;
+import umc.stockoneqback.comment.service.CommentService;
 import umc.stockoneqback.global.config.SecurityConfig;
 import umc.stockoneqback.role.service.CompanyService;
 import umc.stockoneqback.role.service.StoreService;
@@ -26,7 +29,8 @@ import umc.stockoneqback.user.service.UserService;
 @WebMvcTest({
         UserApiController.class,
         BoardApiController.class,
-        BusinessApiController.class
+        BusinessApiController.class,
+        CommentApiController.class
 })
 @AutoConfigureRestDocs
 @WithMockUser
@@ -50,7 +54,7 @@ public abstract class ControllerTest {
     protected BusinessService businessService;
 
     @MockBean
-    protected JwtTokenProvider jwtTokenProvider
+    protected JwtTokenProvider jwtTokenProvider;
     
     @MockBean
     protected UserFindService userFindService;
@@ -60,4 +64,10 @@ public abstract class ControllerTest {
 
     @MockBean
     protected BoardFindService boardFindService;
+
+    @MockBean
+    protected CommentFindService commentFindService;
+
+    @MockBean
+    protected CommentService commentService;
 }

--- a/src/test/java/umc/stockoneqback/common/DatabaseCleaner.java
+++ b/src/test/java/umc/stockoneqback/common/DatabaseCleaner.java
@@ -36,4 +36,10 @@ public class DatabaseCleaner {
 
         entityManager.createNativeQuery("SET foreign_key_checks = 1").executeUpdate();
     }
+
+    @Transactional
+    public void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
 }

--- a/src/test/java/umc/stockoneqback/common/ServiceTest.java
+++ b/src/test/java/umc/stockoneqback/common/ServiceTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import umc.stockoneqback.board.domain.BoardRepository;
 import umc.stockoneqback.business.domain.BusinessRepository;
+import umc.stockoneqback.comment.domain.CommentRepository;
 import umc.stockoneqback.role.domain.company.CompanyRepository;
 import umc.stockoneqback.role.domain.store.PartTimerRepository;
 import umc.stockoneqback.role.domain.store.StoreRepository;
@@ -34,6 +35,13 @@ public class ServiceTest {
   
     @Autowired
     protected BoardRepository boardRepository;
+
+    @Autowired
+    protected CommentRepository commentRepository;
+
+    public void flushAndClear() {
+        databaseCleaner.flushAndClear();
+    }
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## Summary 📌
댓글 등록/수정/삭제 API를 구현한다
## Describe your changes 📝
- 댓글 등록/수정/삭제 API 구현
   - CommentRequest
   - CommentRepository
      - CountByBoard() 추가 (게시글에 달린 댓글 수) 
   - CommentFindService
   - CommentService
   - CommentApiController
 - 테스트 코드
    - CommentRepositoryTeset
    - CommentServiceTest
    - CommentApiControllerTest
    - DatabaseCleaner에 flushAndClear() 추가 
    - BoardServiceTest
         - 게시글 삭제 시 모든 댓글 삭제 테스트에서 commentService.create() 작업이 boardRepository에도 바로 반영되도록 flushAndClear() 작성해서 사용
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️
commentService.create() 하여 영속성 컨텍스트화된 상태를 데이터베이스에 반영시켜서 board에서도 댓글이 달린 걸 인식 할 수 있게 하기 위해서 EntityManager의 flush()를 사용하는 flushAndClear() 작성해서 사용했습니다

참고 글 
- https://www.inflearn.com/questions/917779/spring-data-jpa%EC%97%90%EC%84%9C-flush-%EB%8A%94-%EC%96%B4%EB%96%BB%EA%B2%8C-%ED%95%98%EB%82%98%EC%9A%94
## Issue numbers and link 🚪
Closes #9
