### PR TITLE
[Feat] 커뮤니티 게시글 좋아요 및 취소 API를 구현한다

### DIFF
--- a/src/main/java/umc/stockoneqback/board/controller/like/BoardLikeApiController.java
+++ b/src/main/java/umc/stockoneqback/board/controller/like/BoardLikeApiController.java
@@ -1,0 +1,27 @@
+package umc.stockoneqback.board.controller.like;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import umc.stockoneqback.board.service.like.BoardLikeService;
+import umc.stockoneqback.global.annotation.ExtractPayload;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/boards/{boardId}/likes")
+public class BoardLikeApiController {
+    private final BoardLikeService boardLikeService;
+
+    @PostMapping
+    public ResponseEntity<Void> register(@ExtractPayload Long userId, @PathVariable Long boardId) {
+        boardLikeService.register(userId, boardId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> cancel(@ExtractPayload Long userId, @PathVariable Long boardId) {
+        boardLikeService.cancel(userId, boardId);
+        return ResponseEntity.ok().build();
+    }
+}
+

--- a/src/main/java/umc/stockoneqback/board/domain/like/BoardLike.java
+++ b/src/main/java/umc/stockoneqback/board/domain/like/BoardLike.java
@@ -1,0 +1,36 @@
+package umc.stockoneqback.board.domain.like;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.stockoneqback.board.domain.Board;
+import umc.stockoneqback.user.domain.User;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "board_like")
+public class BoardLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    private BoardLike(User user, Board board) {
+        this.user = user;
+        this.board = board;
+    }
+
+    public static BoardLike registerBoardLike(User user, Board board) {
+        return new BoardLike(user, board);
+    }
+}

--- a/src/main/java/umc/stockoneqback/board/domain/like/BoardLikeRepository.java
+++ b/src/main/java/umc/stockoneqback/board/domain/like/BoardLikeRepository.java
@@ -1,0 +1,18 @@
+package umc.stockoneqback.board.domain.like;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import umc.stockoneqback.board.domain.Board;
+
+public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("DELETE FROM BoardLike i WHERE i.user.id = :userId AND i.board.id = :boardId")
+    void deleteByUserIdAndBoardId(@Param("userId") Long userId, @Param("boardId") Long boardId);
+
+    boolean existsByUserIdAndBoardId(Long userId, Long boardId);
+
+    int countByBoard(Board board);
+}
+

--- a/src/main/java/umc/stockoneqback/board/exception/BoardErrorCode.java
+++ b/src/main/java/umc/stockoneqback/board/exception/BoardErrorCode.java
@@ -10,6 +10,9 @@ import umc.stockoneqback.global.base.ErrorCode;
 public enum BoardErrorCode implements ErrorCode {
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_001", "게시글 정보를 찾을 수 없습니다."),
     USER_IS_NOT_BOARD_WRITER(HttpStatus.CONFLICT, "BOARD_002", "게시글 작성자가 아닙니다."),
+    ALREADY_BOARD_LIKE(HttpStatus.CONFLICT, "BOARD_003","이미 좋아요를 누른 게시글입니다."),
+    SELF_BOARD_LIKE_NOT_ALLOWED(HttpStatus.CONFLICT, "BOARD_004", "본인 게시글은 좋아요를 누를 수 없습니다."),
+    BOARD_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_005", "좋아요를 누르지 않은 게시글은 좋아요 취소를 할 수 없습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/umc/stockoneqback/board/service/like/BoardLikeService.java
+++ b/src/main/java/umc/stockoneqback/board/service/like/BoardLikeService.java
@@ -1,0 +1,59 @@
+package umc.stockoneqback.board.service.like;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.board.domain.Board;
+import umc.stockoneqback.board.domain.like.BoardLike;
+import umc.stockoneqback.board.domain.like.BoardLikeRepository;
+import umc.stockoneqback.board.exception.BoardErrorCode;
+import umc.stockoneqback.board.service.BoardFindService;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.user.domain.User;
+import umc.stockoneqback.user.service.UserFindService;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BoardLikeService {
+    private final UserFindService userFindService;
+    private final BoardFindService boardFindService;
+    private final BoardLikeRepository boardLikeRepository;
+
+    @Transactional
+    public Long register(Long userId, Long boardId){
+        validateSelfBoardLike(userId, boardId);
+        validateAlreadyBoardLike(userId, boardId);
+
+        User user = userFindService.findById(userId);
+        Board board = boardFindService.findById(boardId);
+        BoardLike likeBoard = BoardLike.registerBoardLike(user, board);
+
+        return boardLikeRepository.save(likeBoard).getId();
+    }
+
+    private void validateSelfBoardLike(Long userId, Long boardId) {
+        Board board = boardFindService.findById(boardId);
+        if (board.getWriter().getId().equals(userId)) {
+            throw BaseException.type(BoardErrorCode.SELF_BOARD_LIKE_NOT_ALLOWED);
+        }
+    }
+
+    private void validateAlreadyBoardLike(Long userId, Long boardId) {
+        if (boardLikeRepository.existsByUserIdAndBoardId(userId, boardId)) {
+            throw BaseException.type(BoardErrorCode.ALREADY_BOARD_LIKE);
+        }
+    }
+
+    @Transactional
+    public void cancel(Long userId, Long boardId){
+        validateCancel(userId, boardId);
+        boardLikeRepository.deleteByUserIdAndBoardId(userId, boardId);
+    }
+
+    private void validateCancel(Long userId, Long boardId) {
+        if (!boardLikeRepository.existsByUserIdAndBoardId(userId, boardId)) {
+            throw BaseException.type(BoardErrorCode.BOARD_LIKE_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/umc/stockoneqback/auth/controller/AuthApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/auth/controller/AuthApiControllerTest.java
@@ -169,7 +169,7 @@ class AuthApiControllerTest extends ControllerTest {
             // when
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN);
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
 
             // then
             mockMvc.perform(requestBuilder)

--- a/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static umc.stockoneqback.fixture.BoardFixture.BOARD_0;
 import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
-import static umc.stockoneqback.fixture.TokenFixture.REFRESH_TOKEN;
+import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
 
 @DisplayName("Board [Controller Layer] -> BoardApiController 테스트")
 public class BoardApiControllerTest extends ControllerTest {
@@ -89,7 +89,7 @@ public class BoardApiControllerTest extends ControllerTest {
             final BoardRequest request = createBoardRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -176,7 +176,7 @@ public class BoardApiControllerTest extends ControllerTest {
             final BoardRequest request = createBoardRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, BOARD_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -229,7 +229,7 @@ public class BoardApiControllerTest extends ControllerTest {
             final BoardRequest request = createBoardRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, BOARD_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -315,7 +315,7 @@ public class BoardApiControllerTest extends ControllerTest {
             final BoardRequest request = createBoardRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, BOARD_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -363,7 +363,7 @@ public class BoardApiControllerTest extends ControllerTest {
             final BoardRequest request = createBoardRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, WRITER_ID, BOARD_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 

--- a/src/test/java/umc/stockoneqback/board/controller/like/BoardLikeApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/board/controller/like/BoardLikeApiControllerTest.java
@@ -1,0 +1,331 @@
+package umc.stockoneqback.board.controller.like;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import umc.stockoneqback.auth.exception.AuthErrorCode;
+import umc.stockoneqback.board.exception.BoardErrorCode;
+import umc.stockoneqback.common.ControllerTest;
+import umc.stockoneqback.global.base.BaseException;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
+import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
+
+@DisplayName("Board [Controller Layer] -> BoardLikeApiController 테스트")
+public class BoardLikeApiControllerTest extends ControllerTest {
+    @Nested
+    @DisplayName("게시글좋아요 등록 API [POST /api/boards/{boardId}/likes]")
+    class register {
+        private static final String BASE_URL = "/api/boards/{boardId}/likes";
+        private static final Long USER_ID = 1L;
+        private static final Long BOARD_ID = 2L;
+
+        @Test
+        @DisplayName("Authorization Header에 AccessToken이 없으면 게시글좋아요 등록에 실패한다")
+        void withoutAccessToken() throws Exception {
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL, BOARD_ID);
+
+            // then
+            final AuthErrorCode expectedError = AuthErrorCode.INVALID_PERMISSION;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isForbidden(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BoardApi/Like/Register/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    pathParameters(
+                                            parameterWithName("boardId").description("좋아요를 누를 게시글 ID(PK)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("본인의 게시글에는 좋아요를 누를 수 없다")
+        void throwExceptionBySelfFollowNotAllowed() throws Exception {
+            // given
+            given(jwtTokenProvider.isTokenValid(anyString())).willReturn(true);
+            given(jwtTokenProvider.getId(anyString())).willReturn(USER_ID);
+            doThrow(BaseException.type(BoardErrorCode.SELF_BOARD_LIKE_NOT_ALLOWED))
+                    .when(boardLikeService)
+                    .register(anyLong(), anyLong());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL, BOARD_ID)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final BoardErrorCode expectedError = BoardErrorCode.SELF_BOARD_LIKE_NOT_ALLOWED;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isConflict(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BoardApi/Like/Register/Failure/Case2",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    pathParameters(
+                                            parameterWithName("boardId").description("좋아요를 누를 게시글 ID(PK)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("한 게시글에 두 번 이상 좋아요를 누를 수 없다")
+        void throwExceptionByAlreadyBoardLike() throws Exception {
+            // given
+            given(jwtTokenProvider.isTokenValid(anyString())).willReturn(true);
+            given(jwtTokenProvider.getId(anyString())).willReturn(USER_ID);
+            doThrow(BaseException.type(BoardErrorCode.ALREADY_BOARD_LIKE))
+                    .when(boardLikeService)
+                    .register(anyLong(), anyLong());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL, BOARD_ID)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final BoardErrorCode expectedError = BoardErrorCode.ALREADY_BOARD_LIKE;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isConflict(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BoardApi/Like/Register/Failure/Case3",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    pathParameters(
+                                            parameterWithName("boardId").description("좋아요를 누를 게시글 ID(PK)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("게시글좋아요 등록에 성공한다")
+        void success() throws Exception {
+            // given
+            given(jwtTokenProvider.isTokenValid(anyString())).willReturn(true);
+            given(jwtTokenProvider.getId(anyString())).willReturn(USER_ID);
+            doReturn(1L)
+                    .when(boardLikeService)
+                    .register(anyLong(), anyLong());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL, BOARD_ID)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isNoContent()
+                    )
+                    .andDo(
+                            document(
+                                    "BoardApi/Like/Register/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    pathParameters(
+                                            parameterWithName("boardId").description("좋아요를 누를 게시글 ID(PK)")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글좋아요 취소 API [DELETE /api/boards/{boardId}/likes]")
+    class cancel {
+        private static final String BASE_URL = "/api/boards/{boardId}/likes";
+        private static final Long USER_ID = 1L;
+        private static final Long BOARD_ID = 2L;
+
+        @Test
+        @DisplayName("Authorization Header에 AccessToken이 없으면 게시글좋아요 취소에 실패한다")
+        void withoutAccessToken() throws Exception {
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .delete(BASE_URL, BOARD_ID);
+
+            // then
+            final AuthErrorCode expectedError = AuthErrorCode.INVALID_PERMISSION;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isForbidden(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BoardApi/Cancel/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    pathParameters(
+                                            parameterWithName("boardId").description("좋아요를 취소할 게시글 ID(PK)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("좋아요를 누르지 않은 게시글의 좋아요는 취소할 수 없다")
+        void throwExceptionByBoardLikeNotFound() throws Exception {
+            // given
+            given(jwtTokenProvider.isTokenValid(anyString())).willReturn(true);
+            given(jwtTokenProvider.getId(anyString())).willReturn(USER_ID);
+            doThrow(BaseException.type(BoardErrorCode.BOARD_LIKE_NOT_FOUND))
+                    .when(boardLikeService)
+                    .cancel(anyLong(), anyLong());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .delete(BASE_URL, BOARD_ID)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final BoardErrorCode expectedError = BoardErrorCode.BOARD_LIKE_NOT_FOUND;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BoardApi/Like/Cancel/Failure/Case2",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    pathParameters(
+                                            parameterWithName("boardId").description("좋아요를 취소할 게시글 ID(PK)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("게시글좋아요 취소에 성공한다")
+        void success() throws Exception {
+            // given
+            given(jwtTokenProvider.isTokenValid(anyString())).willReturn(true);
+            given(jwtTokenProvider.getId(anyString())).willReturn(USER_ID);
+            doNothing()
+                    .when(boardLikeService)
+                    .cancel(anyLong(), anyLong());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .delete(BASE_URL, BOARD_ID)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk()
+                    )
+                    .andDo(
+                            document(
+                                    "BoardApi/Register/Cancel/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    pathParameters(
+                                            parameterWithName("boardId").description("좋아요를 취소할 게시글 ID(PK)")
+                                    )
+                            )
+                    );
+        }
+    }
+}

--- a/src/test/java/umc/stockoneqback/board/domain/like/BoardLikeRepositoryTest.java
+++ b/src/test/java/umc/stockoneqback/board/domain/like/BoardLikeRepositoryTest.java
@@ -1,0 +1,82 @@
+package umc.stockoneqback.board.domain.like;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import umc.stockoneqback.board.domain.Board;
+import umc.stockoneqback.board.domain.BoardRepository;
+import umc.stockoneqback.common.RepositoryTest;
+import umc.stockoneqback.user.domain.User;
+import umc.stockoneqback.user.domain.UserRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static umc.stockoneqback.fixture.BoardFixture.BOARD_0;
+import static umc.stockoneqback.fixture.UserFixture.ANNE;
+import static umc.stockoneqback.fixture.UserFixture.SAEWOO;
+
+@DisplayName("Board [Repository Layer] -> BoardLikeRepository 테스트")
+public class BoardLikeRepositoryTest extends RepositoryTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private BoardLikeRepository boardLikeRepository;
+
+    private User user1;
+    private User user2;
+    private Board board;
+
+    @BeforeEach
+    void setup() {
+        user1 = userRepository.save(SAEWOO.toUser());
+        user2 = userRepository.save(ANNE.toUser());
+        board = boardRepository.save(BOARD_0.toBoard(user1));
+    }
+
+    @Test
+    @DisplayName("좋아요를 누른 회원 ID와 좋아요가 눌린 게시글 ID를 이용하여 게시글좋아요 정보가 존재하는지 확인한다")
+    void existsByUserIdAndAndBoardId() {
+        // given
+        boardLikeRepository.save(BoardLike.registerBoardLike(user1, board));
+
+        // when
+        boolean actual1 = boardLikeRepository.existsByUserIdAndBoardId(user1.getId(), board.getId());
+        boolean actual2 = boardLikeRepository.existsByUserIdAndBoardId(user2.getId(), board.getId());
+
+        // then
+        Assertions.assertAll(
+                () -> assertThat(actual1).isTrue(),
+                () -> assertThat(actual2).isFalse()
+        );
+    }
+
+    @Test
+    @DisplayName("좋아요를 누른 회원 ID와 좋아요가 눌린 게시글 ID를 이용하여 게시글좋아요 정보를 삭제한다")
+    void deleteByFollowingIdAndFollowerId() {
+        // given
+        boardLikeRepository.save(BoardLike.registerBoardLike(user1, board));
+
+        // when
+        boardLikeRepository.deleteByUserIdAndBoardId(user1.getId(), board.getId());
+
+        // then
+        assertThat(boardLikeRepository.existsByUserIdAndBoardId(user1.getId(), board.getId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("게시글에 달린 좋아요 수를 확인한다")
+    void countByBoard() {
+        // given
+        boardLikeRepository.save(BoardLike.registerBoardLike(user1, board));
+        boardLikeRepository.save(BoardLike.registerBoardLike(user2, board));
+
+        // when - then
+        assertThat(boardLikeRepository.countByBoard(board)).isEqualTo(2L);
+    }
+}
+

--- a/src/test/java/umc/stockoneqback/board/domain/like/BoardLikeTest.java
+++ b/src/test/java/umc/stockoneqback/board/domain/like/BoardLikeTest.java
@@ -1,0 +1,28 @@
+package umc.stockoneqback.board.domain.like;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import umc.stockoneqback.board.domain.Board;
+import umc.stockoneqback.fixture.BoardFixture;
+import umc.stockoneqback.fixture.UserFixture;
+import umc.stockoneqback.user.domain.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("BoardLike 도메인 테스트")
+public class BoardLikeTest {
+    private static final User user = UserFixture.SAEWOO.toUser();
+    private static final Board board = BoardFixture.BOARD_0.toBoard(user);
+
+    @Test
+    @DisplayName("BoardLike를 생성한다")
+    void registerFollow() {
+        BoardLike boardLike = BoardLike.registerBoardLike(user, board);
+        Assertions.assertAll(
+                () -> assertThat(boardLike.getUser()).isEqualTo(user),
+                () -> assertThat(boardLike.getBoard()).isEqualTo(board)
+        );
+    }
+}
+

--- a/src/test/java/umc/stockoneqback/board/service/like/BoardLikeServiceTest.java
+++ b/src/test/java/umc/stockoneqback/board/service/like/BoardLikeServiceTest.java
@@ -1,0 +1,102 @@
+package umc.stockoneqback.board.service.like;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import umc.stockoneqback.board.domain.Board;
+import umc.stockoneqback.board.domain.like.BoardLike;
+import umc.stockoneqback.board.exception.BoardErrorCode;
+import umc.stockoneqback.common.ServiceTest;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.user.domain.User;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static umc.stockoneqback.fixture.BoardFixture.BOARD_0;
+import static umc.stockoneqback.fixture.UserFixture.ANNE;
+import static umc.stockoneqback.fixture.UserFixture.SAEWOO;
+
+@DisplayName("Board [Service Layer] -> BoardLikeService 테스트")
+public class BoardLikeServiceTest extends ServiceTest {
+    @Autowired
+    private BoardLikeService boardLikeService;
+
+    private User user1;
+    private User user2;
+    private Board board;
+
+    @BeforeEach
+    void setup() {
+        user1 = userRepository.save(SAEWOO.toUser());
+        user2 = userRepository.save(ANNE.toUser());
+        board = boardRepository.save(BOARD_0.toBoard(user1));
+    }
+
+    @Nested
+    @DisplayName("게시글좋아요 등록")
+    class register {
+        @Test
+        @DisplayName("본인의 게시글은 좋아요를 누를 수 없다")
+        void throwExceptionBySelfBoardLikeNotAllowed() {
+            assertThatThrownBy(() -> boardLikeService.register(user1.getId(), board.getId()))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(BoardErrorCode.SELF_BOARD_LIKE_NOT_ALLOWED.getMessage());
+        }
+
+        @Test
+        @DisplayName("한 게시글에 두 번 이상 좋아요를 누를 수 없다")
+        void throwExceptionByAlreadyBoardLike() {
+            // given
+            boardLikeService.register(user2.getId(), board.getId());
+
+            // when - then
+            assertThatThrownBy(() -> boardLikeService.register(user2.getId(), board.getId()))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(BoardErrorCode.ALREADY_BOARD_LIKE.getMessage());
+        }
+
+        @Test
+        @DisplayName("게시글좋아요 등록에 성공한다")
+        void success() {
+            // when
+            Long likeBoardId = boardLikeService.register(user2.getId(), board.getId());
+
+            // then
+            BoardLike findBoardLike = boardLikeRepository.findById(likeBoardId).orElseThrow();
+            assertAll(
+                    () -> assertThat(boardLikeRepository.countByBoard(board)).isEqualTo(1),
+                    () -> assertThat(findBoardLike.getUser().getId()).isEqualTo(user2.getId()),
+                    () -> assertThat(findBoardLike.getBoard().getId()).isEqualTo(board.getId())
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글좋아요 취소")
+    class cancel {
+        @Test
+        @DisplayName("좋아요를 누르지 않은 게시글의 좋아요는 취소할 수 없다")
+        void throwExceptionByBoardLikeNotFound() {
+            // when - then
+            assertThatThrownBy(() -> boardLikeService.cancel(user2.getId(), board.getId()))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(BoardErrorCode.BOARD_LIKE_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("게시글좋아요 취소에 성공한다")
+        void success() {
+            // given
+            boardLikeService.register(user2.getId(), board.getId());
+
+            // when
+            boardLikeService.cancel(user2.getId(), board.getId());
+
+            // then
+            assertThat(boardLikeRepository.existsByUserIdAndBoardId(user2.getId(), board.getId())).isFalse();
+        }
+    }
+}

--- a/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
@@ -7,8 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import umc.stockoneqback.auth.exception.AuthErrorCode;
-import umc.stockoneqback.board.controller.dto.BoardRequest;
-import umc.stockoneqback.board.exception.BoardErrorCode;
 import umc.stockoneqback.comment.controller.dto.CommentRequest;
 import umc.stockoneqback.comment.exception.CommentErrorCode;
 import umc.stockoneqback.common.ControllerTest;
@@ -30,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static umc.stockoneqback.fixture.CommentFixture.COMMENT_0;
 import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
-import static umc.stockoneqback.fixture.TokenFixture.REFRESH_TOKEN;
+import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
 
 @DisplayName("Comment [Controller Layer] -> CommentApiController 테스트")
 public class CommentApiControllerTest extends ControllerTest {
@@ -96,7 +94,7 @@ public class CommentApiControllerTest extends ControllerTest {
             final CommentRequest request = createCommentRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, BOARD_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -186,7 +184,7 @@ public class CommentApiControllerTest extends ControllerTest {
             final CommentRequest request = createCommentRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, COMMENT_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -238,7 +236,7 @@ public class CommentApiControllerTest extends ControllerTest {
             final CommentRequest request = createCommentRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, COMMENT_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -325,7 +323,7 @@ public class CommentApiControllerTest extends ControllerTest {
             final CommentRequest request = createCommentRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, WRITER_ID, COMMENT_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -373,7 +371,7 @@ public class CommentApiControllerTest extends ControllerTest {
             final CommentRequest request = createCommentRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, COMMENT_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 

--- a/src/test/java/umc/stockoneqback/common/ControllerTest.java
+++ b/src/test/java/umc/stockoneqback/common/ControllerTest.java
@@ -18,8 +18,10 @@ import umc.stockoneqback.auth.controller.AuthApiController;
 import umc.stockoneqback.auth.service.AuthService;
 import umc.stockoneqback.auth.utils.JwtTokenProvider;
 import umc.stockoneqback.board.controller.BoardApiController;
+import umc.stockoneqback.board.controller.like.BoardLikeApiController;
 import umc.stockoneqback.board.service.BoardFindService;
 import umc.stockoneqback.board.service.BoardService;
+import umc.stockoneqback.board.service.like.BoardLikeService;
 import umc.stockoneqback.business.controller.BusinessApiController;
 import umc.stockoneqback.business.service.BusinessService;
 import umc.stockoneqback.comment.controller.CommentApiController;
@@ -50,7 +52,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         AuthApiController.class,
         CommentApiController.class,
         ReplyApiController.class,
-        ProductApiController.class
+        ProductApiController.class,
+        BoardLikeApiController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 @AutoConfigureRestDocs
@@ -111,6 +114,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected ReplyService replyService;
+
+    @MockBean
+    protected BoardLikeService boardLikeService;
 
     @BeforeEach
     void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {

--- a/src/test/java/umc/stockoneqback/common/ServiceTest.java
+++ b/src/test/java/umc/stockoneqback/common/ServiceTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import umc.stockoneqback.auth.domain.TokenRepository;
 import umc.stockoneqback.board.domain.BoardRepository;
+import umc.stockoneqback.board.domain.like.BoardLikeRepository;
 import umc.stockoneqback.business.domain.BusinessRepository;
 import umc.stockoneqback.comment.domain.CommentRepository;
 import umc.stockoneqback.product.domain.ProductRepository;
@@ -50,6 +51,9 @@ public class ServiceTest {
   
     @Autowired
     protected ProductRepository productRepository;
+
+    @Autowired
+    protected BoardLikeRepository boardLikeRepository;
 
     public void flushAndClear() {
         databaseCleaner.flushAndClear();

--- a/src/test/java/umc/stockoneqback/reply/controller/ReplyApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/reply/controller/ReplyApiControllerTest.java
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import umc.stockoneqback.auth.exception.AuthErrorCode;
-import umc.stockoneqback.board.exception.BoardErrorCode;
-import umc.stockoneqback.comment.controller.dto.CommentRequest;
 import umc.stockoneqback.common.ControllerTest;
 import umc.stockoneqback.global.base.BaseException;
 import umc.stockoneqback.reply.controller.dto.ReplyRequest;
@@ -25,12 +23,11 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static umc.stockoneqback.fixture.ReplyFixture.REPLY_0;
 import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
-import static umc.stockoneqback.fixture.TokenFixture.REFRESH_TOKEN;
+import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
 
 @DisplayName("Reply [Controller Layer] -> ReplyApiController 테스트")
 public class ReplyApiControllerTest extends ControllerTest {
@@ -96,7 +93,7 @@ public class ReplyApiControllerTest extends ControllerTest {
             final ReplyRequest request = createReplyRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, COMMENT_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -186,7 +183,7 @@ public class ReplyApiControllerTest extends ControllerTest {
             final ReplyRequest request = createReplyRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, REPLY_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -238,7 +235,7 @@ public class ReplyApiControllerTest extends ControllerTest {
             final ReplyRequest request = createReplyRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, REPLY_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -325,7 +322,7 @@ public class ReplyApiControllerTest extends ControllerTest {
             final ReplyRequest request = createReplyRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, WRITER_ID, REPLY_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -373,7 +370,7 @@ public class ReplyApiControllerTest extends ControllerTest {
             final ReplyRequest request = createReplyRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, REPLY_ID)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 

--- a/src/test/java/umc/stockoneqback/user/controller/UserApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/user/controller/UserApiControllerTest.java
@@ -29,7 +29,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
-import static umc.stockoneqback.fixture.TokenFixture.REFRESH_TOKEN;
+import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
 import static umc.stockoneqback.fixture.UserFixture.SAEWOO;
 
 @DisplayName("User [Controller Layer] -> UserApiController 테스트")
@@ -564,7 +564,7 @@ class UserApiControllerTest extends ControllerTest {
             final UserInfoRequest request = createUserInfoRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .put(BASE_URL)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 
@@ -617,7 +617,7 @@ class UserApiControllerTest extends ControllerTest {
             final UserInfoRequest request = createUserInfoRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .put(BASE_URL)
-                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request));
 


### PR DESCRIPTION
## Summary 📌
커뮤니티 게시글 좋아요 및 취소 API를 구현한다
## Describe your changes 📝
- 커뮤니티 게시글 좋아요 및 취소 API 구현
   - BoardLike
   - BoardLikeRepository
      -  deleteByUserIdAndBoardId
      -  existsByUserIdAndBoardId
      -  countByBoard
   - BoardLikeService
   - BoardLikeApiController
   - BoardErrorCode 추가 작성
- 테스트 코드
   - BoardLikeTest
   - BoardLikeRepositoryTest
   - BoardLikeServiceTest
   - BoardLikeApiControllerTest
   - auth, board, user, comment, reply 요청 헤더 REFRESH_TOKEN -> ACCESS_TOKEN으로 수정
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️

## Issue numbers and link 🚪
Closes #37 
