### PR TITLE
[Feat] 게시글 파일, 댓글 이미지 업로드 url 저장을 구현한다

### DIFF
--- a/src/main/java/umc/stockoneqback/board/controller/BoardApiController.java
+++ b/src/main/java/umc/stockoneqback/board/controller/BoardApiController.java
@@ -3,6 +3,7 @@ package umc.stockoneqback.board.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import umc.stockoneqback.board.controller.dto.BoardRequest;
 import umc.stockoneqback.board.service.BoardService;
 import umc.stockoneqback.global.annotation.ExtractPayload;
@@ -17,16 +18,18 @@ public class BoardApiController {
 
     @PostMapping
     public ResponseEntity<Void> create(@ExtractPayload Long writerId,
-                                       @RequestBody @Valid BoardRequest request) {
-        Long boardId = boardService.create(writerId, request.title(), request.file(), request.content());
+                                       @RequestBody @Valid BoardRequest request,
+                                       @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
+        Long boardId = boardService.create(writerId, request.title(), multipartFile, request.content());
         return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/{boardId}")
     public ResponseEntity<Void> update(@ExtractPayload Long writerId,
                                        @PathVariable Long boardId,
-                                       @RequestBody @Valid BoardRequest request) {
-        boardService.update(writerId, boardId, request.title(), request.file(), request.content());
+                                       @RequestBody @Valid BoardRequest request,
+                                       @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
+        boardService.update(writerId, boardId, request.title(), multipartFile, request.content());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/umc/stockoneqback/board/service/BoardService.java
+++ b/src/main/java/umc/stockoneqback/board/service/BoardService.java
@@ -3,9 +3,11 @@ package umc.stockoneqback.board.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import umc.stockoneqback.board.domain.Board;
 import umc.stockoneqback.board.domain.BoardRepository;
 import umc.stockoneqback.board.exception.BoardErrorCode;
+import umc.stockoneqback.file.service.FileService;
 import umc.stockoneqback.global.base.BaseException;
 import umc.stockoneqback.user.domain.User;
 import umc.stockoneqback.user.service.UserFindService;
@@ -17,22 +19,30 @@ public class BoardService {
     private final UserFindService userFindService;
     private final BoardFindService boardFindService;
     private final BoardRepository boardRepository;
+    private final FileService fileService;
 
     @Transactional
-    public Long create(Long writerId, String title, String file, String content){
+    public Long create(Long writerId, String title, MultipartFile file, String content){
         User writer = userFindService.findById(writerId);
-        Board board = Board.createBoard(writer, title ,file, content);
+        String fileUrl = null;
+        if (file != null)
+            fileUrl = fileService.uploadBoardFiles(file);
 
+        Board board = Board.createBoard(writer, title ,fileUrl, content);
         return boardRepository.save(board).getId();
     }
 
     @Transactional
-    public void update(Long writerId, Long boardId, String title, String file, String content){
+    public void update(Long writerId, Long boardId, String title, MultipartFile file, String content){
         validateWriter(boardId, writerId);
         Board board = boardFindService.findById(boardId);
 
+        String fileUrl = null;
+        if (file != null)
+            fileUrl = fileService.uploadBoardFiles(file);
+
         board.updateTitle(title);
-        board.updateFile(file);
+        board.updateFile(fileUrl);
         board.updateContent(content);
     }
 

--- a/src/main/java/umc/stockoneqback/comment/controller/CommentApiController.java
+++ b/src/main/java/umc/stockoneqback/comment/controller/CommentApiController.java
@@ -3,6 +3,7 @@ package umc.stockoneqback.comment.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import umc.stockoneqback.comment.controller.dto.CommentRequest;
 import umc.stockoneqback.comment.service.CommentService;
 import umc.stockoneqback.global.annotation.ExtractPayload;
@@ -17,15 +18,17 @@ public class CommentApiController {
 
     @PostMapping("/{boardId}")
     public ResponseEntity<Void> create(@ExtractPayload Long writerId, @PathVariable Long boardId,
-                                       @RequestBody @Valid CommentRequest request) {
-        commentService.create(writerId, boardId, request.image(), request.content());
+                                       @RequestBody @Valid CommentRequest request,
+                                       @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
+        commentService.create(writerId, boardId, multipartFile, request.content());
         return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/{commentId}")
     public ResponseEntity<Void> update(@ExtractPayload Long writerId, @PathVariable Long commentId,
-                                       @RequestBody @Valid CommentRequest request) {
-        commentService.update(writerId, commentId, request.image(), request.content());
+                                       @RequestBody @Valid CommentRequest request,
+                                       @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
+        commentService.update(writerId, commentId, multipartFile, request.content());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/umc/stockoneqback/comment/service/CommentService.java
+++ b/src/main/java/umc/stockoneqback/comment/service/CommentService.java
@@ -3,11 +3,13 @@ package umc.stockoneqback.comment.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import umc.stockoneqback.board.domain.Board;
 import umc.stockoneqback.board.service.BoardFindService;
 import umc.stockoneqback.comment.domain.Comment;
 import umc.stockoneqback.comment.domain.CommentRepository;
 import umc.stockoneqback.comment.exception.CommentErrorCode;
+import umc.stockoneqback.file.service.FileService;
 import umc.stockoneqback.global.base.BaseException;
 import umc.stockoneqback.user.domain.User;
 import umc.stockoneqback.user.service.UserFindService;
@@ -20,22 +22,30 @@ public class CommentService {
     private final BoardFindService boardFindService;
     private final CommentFindService commentFindService;
     private final CommentRepository commentRepository;
+    private final FileService fileService;
 
     @Transactional
-    public Long create(Long writerId, Long boardId, String image, String content) {
+    public Long create(Long writerId, Long boardId, MultipartFile image, String content) {
         User writer = userFindService.findById(writerId);
         Board board = boardFindService.findById(boardId);
-        Comment comment = Comment.createComment(writer, board, image, content);
+        String imageUrl = null;
+        if (image != null)
+            imageUrl = fileService.uploadBoardFiles(image);
+
+        Comment comment = Comment.createComment(writer, board, imageUrl, content);
 
         return commentRepository.save(comment).getId();
     }
 
     @Transactional
-    public void update(Long writerId, Long commentId, String image, String content) {
+    public void update(Long writerId, Long commentId, MultipartFile image, String content) {
         validateWriter(commentId, writerId);
         Comment comment = commentFindService.findById(commentId);
+        String imageUrl = null;
+        if (image != null)
+            imageUrl = fileService.uploadBoardFiles(image);
 
-        comment.updateImage(image);
+        comment.updateImage(imageUrl);
         comment.updateContent(content);
     }
 

--- a/src/main/java/umc/stockoneqback/reply/controller/ReplyApiController.java
+++ b/src/main/java/umc/stockoneqback/reply/controller/ReplyApiController.java
@@ -3,6 +3,7 @@ package umc.stockoneqback.reply.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import umc.stockoneqback.global.annotation.ExtractPayload;
 import umc.stockoneqback.reply.controller.dto.ReplyRequest;
 import umc.stockoneqback.reply.service.ReplyService;
@@ -17,15 +18,17 @@ public class ReplyApiController {
 
     @PostMapping("/{commentId}")
     public ResponseEntity<Void> create(@ExtractPayload Long writerId, @PathVariable Long commentId,
-                                       @RequestBody @Valid ReplyRequest request) {
-        replyService.create(writerId, commentId, request.image(), request.content());
+                                       @RequestBody @Valid ReplyRequest request,
+                                       @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
+        replyService.create(writerId, commentId, multipartFile, request.content());
         return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/{replyId}")
     public ResponseEntity<Void> update(@ExtractPayload Long writerId, @PathVariable Long replyId,
-                                       @RequestBody @Valid ReplyRequest request) {
-        replyService.update(writerId, replyId, request.image(), request.content());
+                                       @RequestBody @Valid ReplyRequest request,
+                                       @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
+        replyService.update(writerId, replyId, multipartFile, request.content());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/umc/stockoneqback/reply/service/ReplyService.java
+++ b/src/main/java/umc/stockoneqback/reply/service/ReplyService.java
@@ -3,8 +3,10 @@ package umc.stockoneqback.reply.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import umc.stockoneqback.comment.domain.Comment;
 import umc.stockoneqback.comment.service.CommentFindService;
+import umc.stockoneqback.file.service.FileService;
 import umc.stockoneqback.global.base.BaseException;
 import umc.stockoneqback.reply.domain.Reply;
 import umc.stockoneqback.reply.domain.ReplyRepository;
@@ -20,22 +22,30 @@ public class ReplyService {
     private final CommentFindService commentFindService;
     private final ReplyFindService replyFindService;
     private final ReplyRepository replyRepository;
+    private final FileService fileService;
 
     @Transactional
-    public Long create(Long writerId, Long commentId, String image, String content) {
+    public Long create(Long writerId, Long commentId, MultipartFile image, String content) {
         User writer = userFindService.findById(writerId);
         Comment comment = commentFindService.findById(commentId);
-        Reply reply = Reply.createReply(writer, comment, image, content);
+        String imageUrl = null;
+        if (image != null)
+            imageUrl = fileService.uploadBoardFiles(image);
+
+        Reply reply = Reply.createReply(writer, comment, imageUrl, content);
 
         return replyRepository.save(reply).getId();
     }
 
     @Transactional
-    public void update(Long writerId, Long replyId, String image, String content) {
+    public void update(Long writerId, Long replyId, MultipartFile image, String content) {
         validateWriter(replyId, writerId);
         Reply reply = replyFindService.findById(replyId);
+        String imageUrl = null;
+        if (image != null)
+            imageUrl = fileService.uploadBoardFiles(image);
 
-        reply.updateImage(image);
+        reply.updateImage(imageUrl);
         reply.updateContent(content);
     }
 

--- a/src/test/java/umc/stockoneqback/board/service/BoardServiceTest.java
+++ b/src/test/java/umc/stockoneqback/board/service/BoardServiceTest.java
@@ -49,14 +49,14 @@ public class BoardServiceTest extends ServiceTest {
     @DisplayName("게시글 등록에 성공한다")
     void success() {
         // when
-        Long boardId = boardService.create(writer.getId(), "제목", "파일", "내용");
+        Long boardId = boardService.create(writer.getId(), "제목", null, "내용");
 
         // then
         Board findBoard = boardRepository.findById(boardId).orElseThrow();
         assertAll(
                 () -> assertThat(findBoard.getWriter().getId()).isEqualTo(writer.getId()),
                 () -> assertThat(findBoard.getTitle()).isEqualTo("제목"),
-                () -> assertThat(findBoard.getFile()).isEqualTo("파일"),
+                () -> assertThat(findBoard.getFile()).isEqualTo(null),
                 () -> assertThat(findBoard.getContent()).isEqualTo("내용"),
                 () -> assertThat(findBoard.getCreatedDate().format(formatter)).isEqualTo(LocalDateTime.now().format(formatter)),
                 () -> assertThat(findBoard.getModifiedDate().format(formatter)).isEqualTo(LocalDateTime.now().format(formatter))
@@ -70,7 +70,7 @@ public class BoardServiceTest extends ServiceTest {
         @DisplayName("다른 사람의 게시글은 수정할 수 없다")
         void throwExceptionByUserNotBoardWriter() {
             // when - then
-            assertThatThrownBy(() -> boardService.update(not_writer.getId(),board.getId(), "제목2", "파일2", "내용2"))
+            assertThatThrownBy(() -> boardService.update(not_writer.getId(),board.getId(), "제목2", null, "내용2"))
                     .isInstanceOf(BaseException.class)
                     .hasMessage(BoardErrorCode.USER_IS_NOT_BOARD_WRITER.getMessage());
         }
@@ -79,7 +79,7 @@ public class BoardServiceTest extends ServiceTest {
         @DisplayName("게시글 수정에 성공한다")
         void success() {
             // given
-            boardService.update(writer.getId(), board.getId(), "제목2", "파일2","내용2");
+            boardService.update(writer.getId(), board.getId(), "제목2", null,"내용2");
 
             // when
             Board findBoard = boardFindService.findById(board.getId());
@@ -87,7 +87,7 @@ public class BoardServiceTest extends ServiceTest {
             // then
             assertAll(
                     () -> assertThat(findBoard.getTitle()).isEqualTo("제목2"),
-                    () -> assertThat(findBoard.getFile()).isEqualTo("파일2"),
+                    () -> assertThat(findBoard.getFile()).isEqualTo(null),
                     () -> assertThat(findBoard.getContent()).isEqualTo("내용2"),
                     () -> assertThat(findBoard.getModifiedDate().format(formatter)).isEqualTo(LocalDateTime.now().format(formatter))
             );
@@ -111,7 +111,7 @@ public class BoardServiceTest extends ServiceTest {
         void successDeleteAllComment() {
             // given
             for(int i=1; i<=5; i++) {
-                commentService.create(writer.getId(), board.getId(), "이미지" + i, "댓글" + i);
+                commentService.create(writer.getId(), board.getId(), null, "댓글" + i);
             }
             flushAndClear();
 

--- a/src/test/java/umc/stockoneqback/comment/service/CommentServiceTest.java
+++ b/src/test/java/umc/stockoneqback/comment/service/CommentServiceTest.java
@@ -77,7 +77,7 @@ public class CommentServiceTest extends ServiceTest {
         @DisplayName("다른 사람의 댓글은 수정할 수 없다")
         void throwExceptionByUserNotCommentWriter() {
             // when - then
-            assertThatThrownBy(() -> commentService.update(not_writer.getId(),board.getId(), "이미지2", "내용2"))
+            assertThatThrownBy(() -> commentService.update(not_writer.getId(),board.getId(), null, "내용2"))
                     .isInstanceOf(BaseException.class)
                     .hasMessage(CommentErrorCode.USER_IS_NOT_COMMENT_WRITER.getMessage());
         }
@@ -86,14 +86,14 @@ public class CommentServiceTest extends ServiceTest {
         @DisplayName("댓글 수정에 성공한다")
         void success() {
             // given
-            commentService.update(writer.getId(), board.getId(), "이미지2","내용2");
+            commentService.update(writer.getId(), board.getId(), null,"내용2");
 
             // when
             Comment findComment = commentFindService.findById(comments[0].getId());
 
             // then
             assertAll(
-                    () -> assertThat(findComment.getImage()).isEqualTo("이미지2"),
+                    () -> assertThat(findComment.getImage()).isEqualTo(null),
                     () -> assertThat(findComment.getContent()).isEqualTo("내용2"),
                     () -> assertThat(findComment.getModifiedDate().format(formatter)).isEqualTo(LocalDateTime.now().format(formatter))
             );
@@ -132,7 +132,7 @@ public class CommentServiceTest extends ServiceTest {
         void successDeleteAllReply() {
             // given
             for(int i=1; i<=5; i++) {
-                replyService.create(writer.getId(), comments[0].getId(), "이미지" + i, "댓글" + i);
+                replyService.create(writer.getId(), comments[0].getId(), null, "댓글" + i);
             }
             flushAndClear();
 

--- a/src/test/java/umc/stockoneqback/reply/service/ReplyServiceTest.java
+++ b/src/test/java/umc/stockoneqback/reply/service/ReplyServiceTest.java
@@ -78,7 +78,7 @@ public class ReplyServiceTest extends ServiceTest {
         @DisplayName("다른 사람의 대댓글은 수정할 수 없다")
         void throwExceptionByUserNotReplyWriter() {
             // when - then
-            assertThatThrownBy(() -> replyService.update(not_writer.getId(),comment.getId(), "이미지2", "내용2"))
+            assertThatThrownBy(() -> replyService.update(not_writer.getId(),comment.getId(), null, "내용2"))
                     .isInstanceOf(BaseException.class)
                     .hasMessage(ReplyErrorCode.USER_IS_NOT_REPLY_WRITER.getMessage());
         }
@@ -87,14 +87,14 @@ public class ReplyServiceTest extends ServiceTest {
         @DisplayName("대댓글 수정에 성공한다")
         void success() {
             // given
-            replyService.update(writer.getId(), board.getId(), "이미지2","내용2");
+            replyService.update(writer.getId(), board.getId(), null,"내용2");
 
             // when
             Reply reply = replyFindService.findById(replies[0].getId());
 
             // then
             assertAll(
-                    () -> assertThat(reply.getImage()).isEqualTo("이미지2"),
+                    () -> assertThat(reply.getImage()).isEqualTo(null),
                     () -> assertThat(reply.getContent()).isEqualTo("내용2"),
                     () -> assertThat(reply.getModifiedDate().format(formatter)).isEqualTo(LocalDateTime.now().format(formatter))
             );


### PR DESCRIPTION
## Summary 📌
게시글 파일, 댓글 이미지 업로드 url 저장을 구현한다
## Describe your changes 📝
- 게시글 파일, 댓글 이미지 업로드 url 저장 구현
    - 게시글 파일, 댓글 이미지 s3에 올리고 url 저장하는 로직 추가
- 테스트 코드
    - 게시글 파일, 댓글 이미지 서비스 메서드 파라미터 타입 변경에 따라 null로 저장하고 테스트 
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️
request 파일에는 String형 url이 저장되기 떄문에 file을 multiFile 형태로 저장하고 하는 부분은 따로 작성하지 않았는데
이 부분에 대해 수정이 필요한 부분 말해주시면 감사합니다!
## Issue numbers and link 🚪
Closes #59 
