### PR TITLE
[Docs] Spring Rest Docs를 이용하여 API 명세서를 작성한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // Lombok
-    compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.22'
-    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.22'
+    compileOnly("org.projectlombok:lombok")
+    testCompileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+    testAnnotationProcessor("org.projectlombok:lombok")
 
     // Spring Security
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: '2.4.5'
@@ -74,7 +76,6 @@ dependencies {
 ext {
     snippetsDir = file('build/generated-snippets')
 }
-
 
 test {
     outputs.dir snippetsDir

--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -1,0 +1,41 @@
+= Auth 로그인 / 로그아웃 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 사용자 로그인
+=== 1. 비밀번호가 일치하지 않으면 로그인에 실패한다
+HTTP Request
+include::{snippets}/AuthApi/Login/Failure/Case1/http-request.adoc[]
+include::{snippets}/AuthApi/Login/Failure/Case1/request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/AuthApi/Login/Failure/Case1/http-response.adoc[]
+include::{snippets}/AuthApi/Login/Failure/Case1/response-body.adoc[]
+
+=== 2. 로그인에 성공한다
+include::{snippets}/AuthApi/Login/Success/http-request.adoc[]
+include::{snippets}/AuthApi/Login/Success/request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/AuthApi/Login/Success/http-response.adoc[]
+include::{snippets}/AuthApi/Login/Success/response-body.adoc[]
+
+== 사용자 로그아웃
+=== 1. Authorization Header에 AccessToken이 없으면 로그아웃에 실패한다
+HTTP Request
+include::{snippets}/AuthApi/Logout/Failure/Case1/http-request.adoc[]
+
+HTTP Response
+include::{snippets}/AuthApi/Logout/Failure/Case1/http-response.adoc[]
+include::{snippets}/AuthApi/Logout/Failure/Case1/response-body.adoc[]
+
+=== 2. 로그아웃에 성공한다
+HTTP Request
+include::{snippets}/AuthApi/Logout/Success/http-request.adoc[]
+include::{snippets}/AuthApi/Logout/Success/request-headers.adoc[]
+
+HTTP Response
+include::{snippets}/AuthApi/Logout/Success/http-response.adoc[]

--- a/src/docs/asciidoc/friend.adoc
+++ b/src/docs/asciidoc/friend.adoc
@@ -1,0 +1,212 @@
+= FRIEND 친구 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 친구 신청
+=== 1. Authorization Header에 AccessToken이 없으면 친구 신청에 실패한다
+HTTP Request
+include::{snippets}/FriendApi/Request/Failure/Case1/http-request.adoc[]
+include::{snippets}/FriendApi/Request/Failure/Case1/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Request/Failure/Case1/http-response.adoc[]
+include::{snippets}/FriendApi/Request/Failure/Case1/response-fields.adoc[]
+
+=== 2. 본인에게 친구 신청을 할 수 없다
+HTTP Request
+include::{snippets}/FriendApi/Request/Failure/Case2/http-request.adoc[]
+include::{snippets}/FriendApi/Request/Failure/Case2/request-headers.adoc[]
+include::{snippets}/FriendApi/Request/Failure/Case2/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Request/Failure/Case2/http-response.adoc[]
+include::{snippets}/FriendApi/Request/Failure/Case2/response-fields.adoc[]
+
+=== 3. 사장님이 아니라면 친구 요청을 하거나 받을 수 없다
+HTTP Request
+include::{snippets}/FriendApi/Request/Failure/Case3/http-request.adoc[]
+include::{snippets}/FriendApi/Request/Failure/Case3/request-headers.adoc[]
+include::{snippets}/FriendApi/Request/Failure/Case3/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Request/Failure/Case3/http-response.adoc[]
+include::{snippets}/FriendApi/Request/Failure/Case3/response-fields.adoc[]
+
+=== 4. 이미 친구 관계이거나 요청된 관계라면 추가로 요청할 수 없다
+HTTP Request
+include::{snippets}/FriendApi/Request/Failure/Case4/http-request.adoc[]
+include::{snippets}/FriendApi/Request/Failure/Case4/request-headers.adoc[]
+include::{snippets}/FriendApi/Request/Failure/Case4/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Request/Failure/Case4/http-response.adoc[]
+include::{snippets}/FriendApi/Request/Failure/Case4/response-fields.adoc[]
+
+=== 5. 친구 요청에 성공한다
+HTTP Request
+include::{snippets}/FriendApi/Request/Success/http-request.adoc[]
+include::{snippets}/FriendApi/Request/Success/request-headers.adoc[]
+include::{snippets}/FriendApi/Request/Success/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Request/Success/http-response.adoc[]
+
+== 친구 신청 취소
+=== 1. Authorization Header에 AccessToken이 없으면 친구 신청 취소에 실패한다
+HTTP Request
+include::{snippets}/FriendApi/Cancel/Failure/Case1/http-request.adoc[]
+include::{snippets}/FriendApi/Cancel/Failure/Case1/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Cancel/Failure/Case1/http-response.adoc[]
+include::{snippets}/FriendApi/Cancel/Failure/Case1/response-fields.adoc[]
+
+=== 2. 요청된 관계가 존재하지 않는다면 친구 신청 취소에 실패한다
+HTTP Request
+include::{snippets}/FriendApi/Cancel/Failure/Case2/http-request.adoc[]
+include::{snippets}/FriendApi/Cancel/Failure/Case2/request-headers.adoc[]
+include::{snippets}/FriendApi/Cancel/Failure/Case2/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Cancel/Failure/Case2/http-response.adoc[]
+include::{snippets}/FriendApi/Cancel/Failure/Case2/response-fields.adoc[]
+
+=== 3. 이미 승인된 친구 관계라면 친구 신청 취소에 실패한다
+HTTP Request
+include::{snippets}/FriendApi/Cancel/Failure/Case3/http-request.adoc[]
+include::{snippets}/FriendApi/Cancel/Failure/Case3/request-headers.adoc[]
+include::{snippets}/FriendApi/Cancel/Failure/Case3/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Cancel/Failure/Case3/http-response.adoc[]
+include::{snippets}/FriendApi/Cancel/Failure/Case3/response-fields.adoc[]
+
+=== 4. 친구 신청 취소에 성공한다
+HTTP Request
+include::{snippets}/FriendApi/Cancel/Success/http-request.adoc[]
+include::{snippets}/FriendApi/Cancel/Success/request-headers.adoc[]
+include::{snippets}/FriendApi/Cancel/Success/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Cancel/Success/http-response.adoc[]
+
+== 친구 수락
+=== 1. Authorization Header에 AccessToken이 없으면 친구 수락에 실패한다
+HTTP Request
+include::{snippets}/FriendApi/Accept/Failure/Case1/http-request.adoc[]
+include::{snippets}/FriendApi/Accept/Failure/Case1/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Accept/Failure/Case1/http-response.adoc[]
+include::{snippets}/FriendApi/Accept/Failure/Case1/response-fields.adoc[]
+
+=== 2. 요청된 관계가 존재하지 않는다면 친구 수락에 실패한다
+HTTP Request
+include::{snippets}/FriendApi/Accept/Failure/Case2/http-request.adoc[]
+include::{snippets}/FriendApi/Accept/Failure/Case2/request-headers.adoc[]
+include::{snippets}/FriendApi/Accept/Failure/Case2/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Accept/Failure/Case2/http-response.adoc[]
+include::{snippets}/FriendApi/Accept/Failure/Case2/response-fields.adoc[]
+
+=== 3. 이미 승인된 친구 관계라면 친구 수락에 실패한다
+HTTP Request
+include::{snippets}/FriendApi/Accept/Failure/Case3/http-request.adoc[]
+include::{snippets}/FriendApi/Accept/Failure/Case3/request-headers.adoc[]
+include::{snippets}/FriendApi/Accept/Failure/Case3/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Accept/Failure/Case3/http-response.adoc[]
+include::{snippets}/FriendApi/Accept/Failure/Case3/response-fields.adoc[]
+
+=== 4. 친구 수락에 성공한다
+HTTP Request
+include::{snippets}/FriendApi/Accept/Success/http-request.adoc[]
+include::{snippets}/FriendApi/Accept/Success/request-headers.adoc[]
+include::{snippets}/FriendApi/Accept/Success/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Accept/Success/http-response.adoc[]
+
+== 친구 거절
+=== 1. Authorization Header에 AccessToken이 없으면 친구 거절에 실패한다
+HTTP Request
+include::{snippets}/FriendApi/Reject/Failure/Case1/http-request.adoc[]
+include::{snippets}/FriendApi/Reject/Failure/Case1/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Reject/Failure/Case1/http-response.adoc[]
+include::{snippets}/FriendApi/Reject/Failure/Case1/response-fields.adoc[]
+
+=== 2. 요청된 관계가 존재하지 않는다면 친구 신청 거절에 실패한다
+HTTP Request
+include::{snippets}/FriendApi/Reject/Failure/Case2/http-request.adoc[]
+include::{snippets}/FriendApi/Reject/Failure/Case2/request-headers.adoc[]
+include::{snippets}/FriendApi/Reject/Failure/Case2/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Reject/Failure/Case2/http-response.adoc[]
+include::{snippets}/FriendApi/Reject/Failure/Case2/response-fields.adoc[]
+
+=== 3. 이미 승인된 친구 관계라면 친구 신청 거절에 실패한다
+HTTP Request
+include::{snippets}/FriendApi/Reject/Failure/Case3/http-request.adoc[]
+include::{snippets}/FriendApi/Reject/Failure/Case3/request-headers.adoc[]
+include::{snippets}/FriendApi/Reject/Failure/Case3/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Reject/Failure/Case3/http-response.adoc[]
+include::{snippets}/FriendApi/Reject/Failure/Case3/response-fields.adoc[]
+
+=== 4. 친구 신청 거절에 성공한다
+HTTP Request
+include::{snippets}/FriendApi/Reject/Success/http-request.adoc[]
+include::{snippets}/FriendApi/Reject/Success/request-headers.adoc[]
+include::{snippets}/FriendApi/Reject/Success/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Reject/Success/http-response.adoc[]
+
+== 친구 삭제
+=== 1. Authorization Header에 AccessToken이 없으면 친구 삭제에 실패한다
+HTTP Request
+include::{snippets}/FriendApi/Delete/Failure/Case1/http-request.adoc[]
+include::{snippets}/FriendApi/Delete/Failure/Case1/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Delete/Failure/Case1/http-response.adoc[]
+include::{snippets}/FriendApi/Delete/Failure/Case1/response-fields.adoc[]
+
+=== 2. 아직 요청된 친구 관계라면 친구 관계를 삭제할 수 없다
+HTTP Request
+include::{snippets}/FriendApi/Delete/Failure/Case2/http-request.adoc[]
+include::{snippets}/FriendApi/Delete/Failure/Case2/request-headers.adoc[]
+include::{snippets}/FriendApi/Delete/Failure/Case2/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Delete/Failure/Case2/http-response.adoc[]
+include::{snippets}/FriendApi/Delete/Failure/Case2/response-fields.adoc[]
+
+=== 3. 요청된 친구 관계가 존재하지 않는다면 친구 관계를 삭제할 수 없다
+HTTP Request
+include::{snippets}/FriendApi/Delete/Failure/Case3/http-request.adoc[]
+include::{snippets}/FriendApi/Delete/Failure/Case3/request-headers.adoc[]
+include::{snippets}/FriendApi/Delete/Failure/Case3/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Delete/Failure/Case3/http-response.adoc[]
+include::{snippets}/FriendApi/Delete/Failure/Case3/response-fields.adoc[]
+
+=== 4. 친구 관계 삭제에 성공한다
+HTTP Request
+include::{snippets}/FriendApi/Delete/Success/http-request.adoc[]
+include::{snippets}/FriendApi/Delete/Success/request-headers.adoc[]
+include::{snippets}/FriendApi/Delete/Success/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/FriendApi/Delete/Success/http-response.adoc[]
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,11 @@
+= Stock One Q REST Docs [API 문서]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+include::auth.adoc[leveloffset=+1]
+include::user.adoc[leveloffset=+1]
+include::friend.adoc[leveloffset=+1]
+include::token-reissue.adoc[leveloffset=+1]

--- a/src/docs/asciidoc/token-reissue.adoc
+++ b/src/docs/asciidoc/token-reissue.adoc
@@ -1,0 +1,39 @@
+= 토큰 재발급 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 토큰 재발급 [RefreshToken 필수]
+=== 1. Authorization_Header에 RefreshToken이 없으면 예외가 발생한다
+HTTP Request
+include::{snippets}/TokenReissueApi/Failure/Case1/http-request.adoc[]
+
+HTTP Response
+include::{snippets}/TokenReissueApi/Failure/Case1/response-body.adoc[]
+
+=== 2. 만료된 RefreshToken으로 인해 토큰 재발급에 실패한다
+HTTP Request
+include::{snippets}/TokenReissueApi/Failure/Case2/http-request.adoc[]
+include::{snippets}/TokenReissueApi/Failure/Case2/request-headers.adoc[]
+
+HTTP Response
+include::{snippets}/TokenReissueApi/Failure/Case2/response-body.adoc[]
+
+=== 3. 이미 사용했거나 조작된 RefreshToken이면 토큰 재발급에 실패한다
+HTTP Request
+include::{snippets}/TokenReissueApi/Failure/Case3/http-request.adoc[]
+include::{snippets}/TokenReissueApi/Failure/Case3/request-headers.adoc[]
+
+HTTP Response
+include::{snippets}/TokenReissueApi/Failure/Case3/response-body.adoc[]
+
+=== 3. RefresToken으로 AccessToken과 RefreshToken을 재발급받는다
+HTTP Request
+include::{snippets}/TokenReissueApi/Success/http-request.adoc[]
+include::{snippets}/TokenReissueApi/Success/request-headers.adoc[]
+
+HTTP Response
+include::{snippets}/TokenReissueApi/Success/response-body.adoc[]
+include::{snippets}/TokenReissueApi/Success/response-fields.adoc[]

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -1,0 +1,116 @@
+= User 회원가입 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 가게 사장님 등록
+=== 1. 중복된 가게 이름이 존재한다면 가게 사장님 등록에 실패한다
+HTTP Request
+include::{snippets}/UserApi/SignUp/Manager/Failure/Case1/http-request.adoc[]
+include::{snippets}/UserApi/SignUp/Manager/Failure/Case1/request-body.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/SignUp/Manager/Failure/Case1/http-response.adoc[]
+include::{snippets}/UserApi/SignUp/Manager/Failure/Case1/response-fields.adoc[]
+
+=== 2. 중복된 로그인 아이디가 존재한다면 가게 사장님 등록에 실패한다
+HTTP Request
+include::{snippets}/UserApi/SignUp/Manager/Failure/Case2/http-request.adoc[]
+include::{snippets}/UserApi/SignUp/Manager/Failure/Case2/request-body.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/SignUp/Manager/Failure/Case2/http-response.adoc[]
+include::{snippets}/UserApi/SignUp/Manager/Failure/Case2/response-fields.adoc[]
+
+=== 3. 가게 사장님 등록에 성공한다
+HTTP Request
+include::{snippets}/UserApi/SignUp/Manager/Success/http-request.adoc[]
+include::{snippets}/UserApi/SignUp/Manager/Success/request-body.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/SignUp/Manager/Success/http-response.adoc[]
+
+== 아르바이트생 등록 API
+=== 1. 중복된 로그인 아이디가 있다면 아르바이트생 등록에 실패한다
+HTTP Request
+include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case1/http-request.adoc[]
+include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case1/request-body.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case1/http-response.adoc[]
+include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case1/response-fields.adoc[]
+
+=== 2. 가게 코드가 일치하지 않으면 아르바이트생 등록에 실패한다
+HTTP Request
+include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case2/http-request.adoc[]
+include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case2/request-body.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case2/http-response.adoc[]
+include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case2/response-fields.adoc[]
+
+=== 3. 아르바이트생 등록에 성공한다
+HTTP Request
+include::{snippets}/UserApi/SignUp/PartTimer/Success/http-request.adoc[]
+include::{snippets}/UserApi/SignUp/PartTimer/Success/request-body.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/SignUp/PartTimer/Success/http-response.adoc[]
+
+== 슈퍼바이저 등록 API
+=== 1. 중복된 로그인 아이디가 있다면 슈퍼바이저 등록에 실패한다
+HTTP Request
+include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case1/http-request.adoc[]
+include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case1/request-body.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case1/http-response.adoc[]
+include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case1/response-fields.adoc[]
+
+=== 2. 회사 코드가 일치하지 않으면 슈퍼바이저 등록에 실패한다
+HTTP Request
+include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case2/http-request.adoc[]
+include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case2/request-body.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case2/http-response.adoc[]
+include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case2/response-fields.adoc[]
+
+=== 3. 슈퍼바이저 등록에 성공한다
+HTTP Request
+include::{snippets}/UserApi/SignUp/Supervisor/Success/http-request.adoc[]
+include::{snippets}/UserApi/SignUp/Supervisor/Success/request-body.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/SignUp/Supervisor/Success/http-response.adoc[]
+
+== 회원 정보 수정
+=== 1. Authorization Header에 AccessToken이 없으면 회원정보 수정에 실패한다
+HTTP Request
+include::{snippets}/UserApi/Update/Failure/Case1/http-request.adoc[]
+include::{snippets}/UserApi/Update/Failure/Case1/request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/Update/Failure/Case1/http-response.adoc[]
+include::{snippets}/UserApi/Update/Failure/Case1/response-fields.adoc[]
+
+=== 2. 중복된 로그인 아이디가 존재한다면 회원 정보 수정에 실패한다
+HTTP Request
+include::{snippets}/UserApi/Update/Failure/Case2/http-request.adoc[]
+include::{snippets}/UserApi/Update/Failure/Case2/request-headers.adoc[]
+include::{snippets}/UserApi/Update/Failure/Case2/request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/Update/Failure/Case2/http-response.adoc[]
+include::{snippets}/UserApi/Update/Failure/Case2/response-fields.adoc[]
+
+=== 3. 회원 정보 수정에 성공한다
+HTTP Request
+include::{snippets}/UserApi/Update/Success/http-request.adoc[]
+include::{snippets}/UserApi/Update/Success/request-headers.adoc[]
+include::{snippets}/UserApi/Update/Success/request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/Update/Success/http-response.adoc[]

--- a/src/test/java/umc/stockoneqback/auth/controller/AuthApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/auth/controller/AuthApiControllerTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import umc.stockoneqback.auth.controller.dto.request.LoginRequest;
 import umc.stockoneqback.auth.exception.AuthErrorCode;
@@ -82,7 +81,6 @@ class AuthApiControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("로그인에 성공한다")
-        @WithAnonymousUser
         void success() throws Exception {
             // given
             LoginResponse loginResponse = createLoginResponse();

--- a/src/test/java/umc/stockoneqback/auth/controller/TokenReissueApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/auth/controller/TokenReissueApiControllerTest.java
@@ -1,0 +1,187 @@
+package umc.stockoneqback.auth.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import umc.stockoneqback.auth.exception.AuthErrorCode;
+import umc.stockoneqback.auth.service.dto.response.TokenResponse;
+import umc.stockoneqback.common.ControllerTest;
+import umc.stockoneqback.global.base.BaseException;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static umc.stockoneqback.fixture.TokenFixture.*;
+
+@DisplayName("Auth [Controller Layer] -> TokenReissueApiController 테스트")
+class TokenReissueApiControllerTest extends ControllerTest {
+    @Nested
+    @DisplayName("토큰 재발급 API 테스트 [POST /api/token/reissue]")
+    class reissueTokens {
+        private static final String BASE_URL = "/api/token/reissue";
+
+        @Test
+        @DisplayName("Authorization_Header에 RefreshToken이 없으면 예외가 발생한다")
+        void throwExceptionByInvalidPermission() throws Exception {
+            // when
+            MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.post(BASE_URL);
+
+            // then
+            final AuthErrorCode expectedError = AuthErrorCode.INVALID_PERMISSION;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isForbidden(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "TokenReissueApi/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("만료된 RefreshToken으로 인해 토큰 재발급에 실패한다")
+        void throwExceptionByAuthExpiredToken() throws Exception {
+            // given
+            given(jwtTokenProvider.getId(anyString()))
+                    .willThrow(BaseException.type(AuthErrorCode.AUTH_EXPIRED_TOKEN));
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                    .post(BASE_URL)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN);
+
+            // then
+            final AuthErrorCode expectedError = AuthErrorCode.AUTH_EXPIRED_TOKEN;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isUnauthorized(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "TokenReissueApi/Failure/Case2",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Refresh Token")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("이미 사용한 RefreshToken이거나 조작된 RefreshToken이면 재발급에 실패한다")
+        void throwExceptionByAuthInvalidToken() throws Exception {
+            // given
+            given(jwtTokenProvider.getId(anyString()))
+                    .willThrow(BaseException.type(AuthErrorCode.AUTH_INVALID_TOKEN));
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                    .post(BASE_URL)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN);
+
+            // then
+            final AuthErrorCode expectedError = AuthErrorCode.AUTH_INVALID_TOKEN;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isUnauthorized(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "TokenReissueApi/Failure/Case3",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Refresh Token")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("RefreshToken으로 AccessToken과 RefreshToken을 재발급받는다.")
+        void success() throws Exception {
+            // given
+            given(jwtTokenProvider.isTokenValid(REFRESH_TOKEN)).willReturn(true);
+            given(jwtTokenProvider.getId(REFRESH_TOKEN)).willReturn(1L);
+
+            TokenResponse response = new TokenResponse(ACCESS_TOKEN, REFRESH_TOKEN);
+            given(tokenReissueService.reissueTokens(1L, REFRESH_TOKEN)).willReturn(response);
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                    .post(BASE_URL)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + REFRESH_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.accessToken").exists(),
+                            jsonPath("$.accessToken").value(ACCESS_TOKEN),
+                            jsonPath("$.refreshToken").exists(),
+                            jsonPath("$.refreshToken").value(REFRESH_TOKEN)
+                    )
+                    .andDo(
+                            document(
+                                    "TokenReissueApi/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Refresh Token")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("accessToken").description("새로 발급된 Access Token (Expire - 2시간)"),
+                                            fieldWithPath("refreshToken").description("새로 발급된 Refresh Token (Expire - 2주)")
+                                    )
+                            )
+                    );
+        }
+    }
+}

--- a/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
@@ -26,8 +26,8 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static umc.stockoneqback.fixture.BoardFixture.BOARD_0;
-import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
 import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
+import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
 
 @DisplayName("Board [Controller Layer] -> BoardApiController 테스트")
 public class BoardApiControllerTest extends ControllerTest {

--- a/src/test/java/umc/stockoneqback/board/controller/like/BoardLikeApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/board/controller/like/BoardLikeApiControllerTest.java
@@ -25,8 +25,8 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
 import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
+import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
 
 @DisplayName("Board [Controller Layer] -> BoardLikeApiController 테스트")
 public class BoardLikeApiControllerTest extends ControllerTest {

--- a/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/comment/controller/CommentApiControllerTest.java
@@ -27,8 +27,8 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static umc.stockoneqback.fixture.CommentFixture.COMMENT_0;
-import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
 import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
+import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
 
 @DisplayName("Comment [Controller Layer] -> CommentApiController 테스트")
 public class CommentApiControllerTest extends ControllerTest {

--- a/src/test/java/umc/stockoneqback/common/ControllerTest.java
+++ b/src/test/java/umc/stockoneqback/common/ControllerTest.java
@@ -15,7 +15,9 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 import umc.stockoneqback.auth.controller.AuthApiController;
+import umc.stockoneqback.auth.controller.TokenReissueApiController;
 import umc.stockoneqback.auth.service.AuthService;
+import umc.stockoneqback.auth.service.TokenReissueService;
 import umc.stockoneqback.auth.utils.JwtTokenProvider;
 import umc.stockoneqback.board.controller.BoardApiController;
 import umc.stockoneqback.board.controller.like.BoardLikeApiController;
@@ -59,7 +61,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         ProductApiController.class,
         FriendApiController.class,
         FriendFindApiController.class,
-        BoardLikeApiController.class
+        BoardLikeApiController.class,
+        TokenReissueApiController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 @AutoConfigureRestDocs
@@ -129,6 +132,9 @@ public abstract class ControllerTest {
   
     @MockBean
     protected BoardLikeService boardLikeService;
+
+    @MockBean
+    protected TokenReissueService tokenReissueService;
 
     @BeforeEach
     void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {

--- a/src/test/java/umc/stockoneqback/reply/controller/ReplyApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/reply/controller/ReplyApiControllerTest.java
@@ -26,8 +26,8 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static umc.stockoneqback.fixture.ReplyFixture.REPLY_0;
-import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
 import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
+import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
 
 @DisplayName("Reply [Controller Layer] -> ReplyApiController 테스트")
 public class ReplyApiControllerTest extends ControllerTest {

--- a/src/test/java/umc/stockoneqback/user/controller/UserApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/user/controller/UserApiControllerTest.java
@@ -28,8 +28,8 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
 import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
+import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
 import static umc.stockoneqback.fixture.UserFixture.SAEWOO;
 
 @DisplayName("User [Controller Layer] -> UserApiController 테스트")
@@ -405,7 +405,7 @@ class UserApiControllerTest extends ControllerTest {
         }
 
         @Test
-        @DisplayName("중복된 로그인 아이디가 있다면 슈퍼바이저 등록에 실패한다")
+        @DisplayName("회사 코드가 일치하지 않으면 슈퍼바이저 등록에 실패한다")
         void throwExceptionByInvalidCompanyCode() throws Exception {
             // given
             doThrow(BaseException.type(UserErrorCode.INVALID_COMPANY_CODE))


### PR DESCRIPTION
## Summary 📌
- Spring Rest Docs를 이용하여 API 명세서를 작성한다

## Describe your changes 📝
- auth.adoc
- token-reissue.adoc
- user.adoc
- friend.adoc

## Check list ✅
- [X] I write PR according to the form
- [X] All tests are passed
- [X] Program works normally
- [X] I set proper PR labels
- [X] I remove any redundant codes

## Opinions 🗣️
- 이렇게 adoc 생성해서 빌드하면 ./build/docs/asciidoc에 html로 변환된 파일 생깁니다.
- 이 html 파일들이 github에 올라가지는 않아요.
- 따라서, 노션에 다음과 같이 올려주셔서 프론트에게 전달하면 될 것 같아요.
<img width="1418" alt="image" src="https://github.com/stockOneQ/back/assets/109421279/8c59882d-d639-4a1c-8de2-0f0fa185b031">

## Issue numbers and link 🚪
Closes #50 
