### PR TITLE
[feat] 게시글, 댓글, 대댓글 ApiController를 수정한다

### DIFF
--- a/src/docs/asciidoc/board.adoc
+++ b/src/docs/asciidoc/board.adoc
@@ -1,0 +1,158 @@
+= Board 등록 / 수정 / 삭제 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 게시글 등록
+=== 1. Authorization Header에 AccessToken이 없으면 게시글 등록에 실패한다
+HTTP Request
+include::{snippets}/BoardApi/Create/Failure/Case1/http-request.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Create/Failure/Case1/http-response.adoc[]
+include::{snippets}/BoardApi/Create/Failure/Case1/response-fields.adoc[]
+
+==== 2. 게시글 등록에 성공한다
+HTTP Request
+include::{snippets}/BoardApi/Create/Success/http-request.adoc[]
+include::{snippets}/BoardApi/Create/Success/request-headers.adoc[]
+include::{snippets}/BoardApi/Create/Success/request-parts.adoc[]
+include::{snippets}/BoardApi/Create/Success/request-part-request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Create/Success/http-response.adoc[]
+
+== 게시글 수정
+=== 1. Authorization Header에 AccessToken이 없으면 게시글 수정에 실패한다
+HTTP Request
+include::{snippets}/BoardApi/Update/Failure/Case1/http-request.adoc[]
+include::{snippets}/BoardApi/Update/Failure/Case1/request-parts.adoc[]
+include::{snippets}/BoardApi/Update/Failure/Case1/request-part-request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Update/Failure/Case1/http-response.adoc[]
+include::{snippets}/BoardApi/Update/Failure/Case1/response-fields.adoc[]
+
+=== 2. 다른 사람의 게시글은 수정할 수 없다
+HTTP Request
+include::{snippets}/BoardApi/Update/Failure/Case2/http-request.adoc[]
+include::{snippets}/BoardApi/Update/Failure/Case2/request-headers.adoc[]
+include::{snippets}/BoardApi/Update/Failure/Case2/path-parameters.adoc[]
+include::{snippets}/BoardApi/Update/Failure/Case1/request-parts.adoc[]
+include::{snippets}/BoardApi/Update/Failure/Case1/request-part-request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Update/Failure/Case2/http-response.adoc[]
+include::{snippets}/BoardApi/Update/Failure/Case2/response-fields.adoc[]
+
+=== 3. 게시글 수정에 성공한다
+HTTP Request
+include::{snippets}/BoardApi/Update/Success/http-request.adoc[]
+include::{snippets}/BoardApi/Update/Success/request-headers.adoc[]
+include::{snippets}/BoardApi/Update/Success/path-parameters.adoc[]
+include::{snippets}/BoardApi/Update/Success/request-parts.adoc[]
+include::{snippets}/BoardApi/Update/Success/request-part-request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Update/Success/http-response.adoc[]
+
+== 게시글 삭제
+=== 1. Authorization Header에 AccessToken이 없으면 게시글 삭제에 실패한다
+HTTP Request
+include::{snippets}/BoardApi/Delete/Failure/Case1/http-request.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Delete/Failure/Case1/http-response.adoc[]
+include::{snippets}/BoardApi/Delete/Failure/Case1/response-fields.adoc[]
+
+=== 2. 다른 사람의 게시글은 삭제할 수 없다
+HTTP Request
+include::{snippets}/BoardApi/Delete/Failure/Case2/http-request.adoc[]
+include::{snippets}/BoardApi/Delete/Failure/Case2/request-headers.adoc[]
+include::{snippets}/BoardApi/Delete/Failure/Case2/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Delete/Failure/Case2/http-response.adoc[]
+include::{snippets}/BoardApi/Delete/Failure/Case2/response-fields.adoc[]
+
+=== 3. 게시글 삭제에 성공한다
+HTTP Request
+include::{snippets}/BoardApi/Delete/Success/http-request.adoc[]
+include::{snippets}/BoardApi/Delete/Success/request-headers.adoc[]
+include::{snippets}/BoardApi/Delete/Success/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Delete/Success/http-response.adoc[]
+
+
+= Board Like 등록 / 취소 API
+
+== 게시글 좋아요 등록
+=== 1. Authorization Header에 AccessToken이 없으면 게시글 좋아요 등록에 실패한다
+HTTP Request
+include::{snippets}/BoardApi/Like/Cancel/Failure/Case1/http-request.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Like/Register/Failure/Case1/http-response.adoc[]
+include::{snippets}/BoardApi/Like/Register/Failure/Case1/response-fields.adoc[]
+
+=== 2. 본인의 게시글에는 좋아요를 누를 수 없다
+HTTP Request
+include::{snippets}/BoardApi/Like/Register/Failure/Case2/http-request.adoc[]
+include::{snippets}/BoardApi/Like/Register/Failure/Case2/request-headers.adoc[]
+include::{snippets}/BoardApi/Like/Register/Failure/Case2/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Like/Register/Failure/Case2/http-response.adoc[]
+include::{snippets}/BoardApi/Like/Register/Failure/Case2/response-fields.adoc[]
+
+==== 3. 한 게시글에 두 번 이상 좋아요를 누를 수 없다
+HTTP Request
+include::{snippets}/BoardApi/Like/Register/Failure/Case3/http-request.adoc[]
+include::{snippets}/BoardApi/Like/Register/Failure/Case3/request-headers.adoc[]
+include::{snippets}/BoardApi/Like/Register/Failure/Case3/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Like/Register/Failure/Case3/http-response.adoc[]
+include::{snippets}/BoardApi/Like/Register/Failure/Case3/response-fields.adoc[]
+
+
+
+==== 4. 게시글 좋아요 등록에 성공한다
+HTTP Request
+include::{snippets}/BoardApi/Like/Register/Success/http-request.adoc[]
+include::{snippets}/BoardApi/Like/Register/Success/request-headers.adoc[]
+include::{snippets}/BoardApi/Like/Register/Success/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Like/Register/Success/http-response.adoc[]
+
+== 게시글 좋아요 취소
+=== 1. Authorization Header에 AccessToken이 없으면 게시글 좋아요 취소에 실패한다
+HTTP Request
+include::{snippets}/BoardApi/Like/Cancel/Failure/Case1/http-request.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Like/Cancel/Failure/Case1/http-response.adoc[]
+include::{snippets}/BoardApi/Like/Cancel/Failure/Case1/response-fields.adoc[]
+
+=== 2. 좋아요를 누르지 않은 게시글의 좋아요는 취소할 수 없다
+HTTP Request
+include::{snippets}/BoardApi/Like/Cancel/Failure/Case2/http-request.adoc[]
+include::{snippets}/BoardApi/Like/Register/Failure/Case3/request-headers.adoc[]
+include::{snippets}/BoardApi/Like/Register/Failure/Case3/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Like/Cancel/Failure/Case2/http-response.adoc[]
+include::{snippets}/BoardApi/Like/Cancel/Failure/Case2/response-fields.adoc[]
+
+=== 3. 게시글좋아요 취소에 성공한다
+HTTP Request
+include::{snippets}/BoardApi/Like/Cancel/Success/http-request.adoc[]
+include::{snippets}/BoardApi/Like/Register/Failure/Case3/request-headers.adoc[]
+include::{snippets}/BoardApi/Like/Register/Failure/Case3/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Like/Cancel/Success/http-response.adoc[]

--- a/src/docs/asciidoc/comment.adoc
+++ b/src/docs/asciidoc/comment.adoc
@@ -1,0 +1,87 @@
+= Comment 등록 / 수정 / 삭제 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 댓글 등록
+=== 1. Authorization Header에 AccessToken이 없으면 댓글 등록에 실패한다
+HTTP Request
+include::{snippets}/CommentApi/Create/Failure/Case1/http-request.adoc[]
+
+HTTP Response
+include::{snippets}/CommentApi/Create/Failure/Case1/http-response.adoc[]
+include::{snippets}/CommentApi/Create/Failure/Case1/response-fields.adoc[]
+
+==== 2. 댓글 등록에 성공한다
+HTTP Request
+include::{snippets}/CommentApi/Create/Success/http-request.adoc[]
+include::{snippets}/CommentApi/Create/Success/request-headers.adoc[]
+include::{snippets}/CommentApi/Create/Success/path-parameters.adoc[]
+include::{snippets}/CommentApi/Create/Success/request-parts.adoc[]
+include::{snippets}/CommentApi/Create/Success/request-part-request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/CommentApi/Create/Success/http-response.adoc[]
+
+== 댓글 수정
+=== 1. Authorization Header에 AccessToken이 없으면 댓글 수정에 실패한다
+HTTP Request
+include::{snippets}/CommentApi/Update/Failure/Case1/http-request.adoc[]
+
+HTTP Response
+include::{snippets}/CommentApi/Update/Failure/Case1/http-response.adoc[]
+include::{snippets}/CommentApi/Update/Failure/Case1/response-fields.adoc[]
+
+=== 2. 다른 사람의 댓글은 수정할 수 없다
+HTTP Request
+include::{snippets}/CommentApi/Update/Failure/Case2/http-request.adoc[]
+include::{snippets}/CommentApi/Update/Failure/Case2/request-headers.adoc[]
+include::{snippets}/CommentApi/Update/Failure/Case2/path-parameters.adoc[]
+include::{snippets}/CommentApi/Update/Failure/Case2/request-parts.adoc[]
+include::{snippets}/CommentApi/Update/Failure/Case2/request-part-request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/CommentApi/Update/Failure/Case2/http-response.adoc[]
+include::{snippets}/CommentApi/Update/Failure/Case2/response-fields.adoc[]
+
+=== 3. 댓글 수정에 성공한다
+HTTP Request
+include::{snippets}/CommentApi/Update/Success/http-request.adoc[]
+include::{snippets}/CommentApi/Update/Success/request-headers.adoc[]
+include::{snippets}/CommentApi/Update/Success/path-parameters.adoc[]
+include::{snippets}/CommentApi/Update/Success/request-parts.adoc[]
+include::{snippets}/CommentApi/Update/Success/request-part-request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/CommentApi/Update/Success/http-response.adoc[]
+
+== 댓글 삭제
+=== 1. Authorization Header에 AccessToken이 없으면 댓글 삭제에 실패한다
+HTTP Request
+include::{snippets}/CommentApi/Delete/Failure/Case1/http-request.adoc[]
+
+HTTP Response
+include::{snippets}/CommentApi/Delete/Failure/Case1/http-response.adoc[]
+include::{snippets}/CommentApi/Delete/Failure/Case1/response-fields.adoc[]
+
+=== 2. 다른 사람의 댓글은 삭제할 수 없다
+HTTP Request
+include::{snippets}/CommentApi/Delete/Failure/Case2/http-request.adoc[]
+include::{snippets}/CommentApi/Delete/Failure/Case2/request-headers.adoc[]
+include::{snippets}/CommentApi/Delete/Failure/Case2/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/CommentApi/Delete/Failure/Case2/http-response.adoc[]
+include::{snippets}/CommentApi/Delete/Failure/Case2/response-fields.adoc[]
+
+=== 3. 댓글 삭제에 성공한다
+HTTP Request
+include::{snippets}/CommentApi/Delete/Success/http-request.adoc[]
+include::{snippets}/CommentApi/Delete/Success/
+include::{snippets}/CommentApi/Delete/Success/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/CommentApi/Delete/Success/http-response.adoc[]
+

--- a/src/docs/asciidoc/reply.adoc
+++ b/src/docs/asciidoc/reply.adoc
@@ -1,0 +1,91 @@
+= Reply 등록 / 수정 / 삭제 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 대댓글 등록
+=== 1. Authorization Header에 AccessToken이 없으면 대댓글 등록에 실패한다
+HTTP Request
+include::{snippets}/ReplyApi/Create/Failure/Case1/http-request.adoc[]
+
+HTTP Response
+include::{snippets}/ReplyApi/Create/Failure/Case1/http-response.adoc[]
+include::{snippets}/ReplyApi/Create/Failure/Case1/response-fields.adoc[]
+
+==== 2. 대댓글 등록에 성공한다
+HTTP Request
+include::{snippets}/ReplyApi/Create/Success/http-request.adoc[]
+include::{snippets}/ReplyApi/Create/Success/request-headers.adoc[]
+include::{snippets}/ReplyApi/Create/Success/path-parameters.adoc[]
+include::{snippets}/CommentApi/Create/Success/request-parts.adoc[]
+include::{snippets}/CommentApi/Create/Success/request-part-request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/ReplyApi/Create/Success/http-response.adoc[]
+
+== 대댓글 수정
+=== 1. Authorization Header에 AccessToken이 없으면 대댓글 수정에 실패한다
+HTTP Request
+include::{snippets}/ReplyApi/Update/Failure/Case1/http-request.adoc[]
+
+HTTP Response
+include::{snippets}/ReplyApi/Update/Failure/Case1/http-response.adoc[]
+include::{snippets}/ReplyApi/Update/Failure/Case1/response-fields.adoc[]
+
+=== 2. 다른 사람의 대댓글은 수정할 수 없다
+HTTP Request
+include::{snippets}/ReplyApi/Update/Failure/Case2/http-request.adoc[]
+include::{snippets}/ReplyApi/Update/Failure/Case2/request-headers.adoc[]
+include::{snippets}/ReplyApi/Update/Failure/Case2/path-parameters.adoc[]
+include::{snippets}/CommentApi/Create/Success/request-parts.adoc[]
+include::{snippets}/CommentApi/Create/Success/request-part-request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/ReplyApi/Update/Failure/Case2/http-response.adoc[]
+include::{snippets}/ReplyApi/Update/Failure/Case2/response-fields.adoc[]
+
+=== 3. 대댓글 수정에 성공한다
+HTTP Request
+include::{snippets}/ReplyApi/Update/Success/http-request.adoc[]
+include::{snippets}/ReplyApi/Update/Success/request-headers.adoc[]
+include::{snippets}/ReplyApi/Update/Success/path-parameters.adoc[]
+include::{snippets}/CommentApi/Create/Success/request-parts.adoc[]
+include::{snippets}/CommentApi/Create/Success/request-part-request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/ReplyApi/Update/Success/http-response.adoc[]
+
+== 대댓글 삭제
+=== 1. Authorization Header에 AccessToken이 없으면 대댓글 삭제에 실패한다
+HTTP Request
+include::{snippets}/ReplyApi/Delete/Failure/Case1/http-request.adoc[]
+
+HTTP Response
+include::{snippets}/ReplyApi/Delete/Failure/Case1/http-response.adoc[]
+include::{snippets}/ReplyApi/Delete/Failure/Case1/response-fields.adoc[]
+
+=== 2. 다른 사람의 대댓글은 삭제할 수 없다
+HTTP Request
+include::{snippets}/ReplyApi/Delete/Failure/Case2/http-request.adoc[]
+include::{snippets}/ReplyApi/Delete/Failure/Case2/request-headers.adoc[]
+include::{snippets}/ReplyApi/Delete/Failure/Case2/path-parameters.adoc[]
+include::{snippets}/CommentApi/Create/Success/request-parts.adoc[]
+include::{snippets}/CommentApi/Create/Success/request-part-request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/ReplyApi/Delete/Failure/Case2/http-response.adoc[]
+include::{snippets}/ReplyApi/Delete/Failure/Case2/response-fields.adoc[]
+
+=== 3. 대댓글 삭제에 성공한다
+HTTP Request
+include::{snippets}/ReplyApi/Delete/Success/http-request.adoc[]
+include::{snippets}/ReplyApi/Delete/Success/request-headers.adoc[]
+include::{snippets}/ReplyApi/Delete/Success/path-parameters.adoc[]
+include::{snippets}/CommentApi/Create/Success/request-parts.adoc[]
+include::{snippets}/CommentApi/Create/Success/request-part-request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/ReplyApi/Delete/Success/http-response.adoc[]
+

--- a/src/main/java/umc/stockoneqback/board/controller/BoardApiController.java
+++ b/src/main/java/umc/stockoneqback/board/controller/BoardApiController.java
@@ -18,8 +18,8 @@ public class BoardApiController {
 
     @PostMapping
     public ResponseEntity<Void> create(@ExtractPayload Long writerId,
-                                       @RequestBody @Valid BoardRequest request,
-                                       @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
+                                       @RequestPart(value = "request") @Valid BoardRequest request,
+                                       @RequestPart(value = "file", required = false) MultipartFile multipartFile) {
         Long boardId = boardService.create(writerId, request.title(), multipartFile, request.content());
         return ResponseEntity.ok().build();
     }
@@ -27,8 +27,8 @@ public class BoardApiController {
     @PatchMapping("/{boardId}")
     public ResponseEntity<Void> update(@ExtractPayload Long writerId,
                                        @PathVariable Long boardId,
-                                       @RequestBody @Valid BoardRequest request,
-                                       @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
+                                       @RequestPart(value = "request")  @Valid BoardRequest request,
+                                       @RequestPart(value = "file", required = false) MultipartFile multipartFile) {
         boardService.update(writerId, boardId, request.title(), multipartFile, request.content());
         return ResponseEntity.ok().build();
     }
@@ -36,6 +36,6 @@ public class BoardApiController {
     @DeleteMapping("/{boardId}")
     public ResponseEntity<Void> delete(@ExtractPayload Long writerId, @PathVariable Long boardId) {
         boardService.delete(writerId, boardId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/umc/stockoneqback/board/controller/like/BoardLikeApiController.java
+++ b/src/main/java/umc/stockoneqback/board/controller/like/BoardLikeApiController.java
@@ -15,7 +15,7 @@ public class BoardLikeApiController {
     @PostMapping
     public ResponseEntity<Void> register(@ExtractPayload Long userId, @PathVariable Long boardId) {
         boardLikeService.register(userId, boardId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping

--- a/src/main/java/umc/stockoneqback/comment/controller/CommentApiController.java
+++ b/src/main/java/umc/stockoneqback/comment/controller/CommentApiController.java
@@ -18,7 +18,7 @@ public class CommentApiController {
 
     @PostMapping("/{boardId}")
     public ResponseEntity<Void> create(@ExtractPayload Long writerId, @PathVariable Long boardId,
-                                       @RequestBody @Valid CommentRequest request,
+                                       @RequestPart(value = "request")  @Valid CommentRequest request,
                                        @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
         commentService.create(writerId, boardId, multipartFile, request.content());
         return ResponseEntity.ok().build();
@@ -26,7 +26,7 @@ public class CommentApiController {
 
     @PatchMapping("/{commentId}")
     public ResponseEntity<Void> update(@ExtractPayload Long writerId, @PathVariable Long commentId,
-                                       @RequestBody @Valid CommentRequest request,
+                                       @RequestPart(value = "request")  @Valid CommentRequest request,
                                        @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
         commentService.update(writerId, commentId, multipartFile, request.content());
         return ResponseEntity.ok().build();

--- a/src/main/java/umc/stockoneqback/reply/controller/ReplyApiController.java
+++ b/src/main/java/umc/stockoneqback/reply/controller/ReplyApiController.java
@@ -18,7 +18,7 @@ public class ReplyApiController {
 
     @PostMapping("/{commentId}")
     public ResponseEntity<Void> create(@ExtractPayload Long writerId, @PathVariable Long commentId,
-                                       @RequestBody @Valid ReplyRequest request,
+                                       @RequestPart(value = "request")  @Valid ReplyRequest request,
                                        @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
         replyService.create(writerId, commentId, multipartFile, request.content());
         return ResponseEntity.ok().build();
@@ -26,7 +26,7 @@ public class ReplyApiController {
 
     @PatchMapping("/{replyId}")
     public ResponseEntity<Void> update(@ExtractPayload Long writerId, @PathVariable Long replyId,
-                                       @RequestBody @Valid ReplyRequest request,
+                                       @RequestPart(value = "request")  @Valid ReplyRequest request,
                                        @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
         replyService.update(writerId, replyId, multipartFile, request.content());
         return ResponseEntity.ok().build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: none
     properties:
       hibernate:
         show_sql: false

--- a/src/test/java/umc/stockoneqback/board/controller/like/BoardLikeApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/board/controller/like/BoardLikeApiControllerTest.java
@@ -185,7 +185,7 @@ public class BoardLikeApiControllerTest extends ControllerTest {
             // then
             mockMvc.perform(requestBuilder)
                     .andExpectAll(
-                            status().isNoContent()
+                            status().isOk()
                     )
                     .andDo(
                             document(
@@ -231,7 +231,7 @@ public class BoardLikeApiControllerTest extends ControllerTest {
                     )
                     .andDo(
                             document(
-                                    "BoardApi/Cancel/Failure/Case1",
+                                    "BoardApi/Like/Cancel/Failure/Case1",
                                     preprocessRequest(prettyPrint()),
                                     preprocessResponse(prettyPrint()),
                                     pathParameters(
@@ -315,7 +315,7 @@ public class BoardLikeApiControllerTest extends ControllerTest {
                     )
                     .andDo(
                             document(
-                                    "BoardApi/Register/Cancel/Success",
+                                    "BoardApi/Like/Cancel/Success",
                                     preprocessRequest(prettyPrint()),
                                     preprocessResponse(prettyPrint()),
                                     requestHeaders(


### PR DESCRIPTION
## Summary 📌
게시글, 댓글, 대댓글 apiController를 수정한다
## Describe your changes 📝
- 게시글, 댓글, 대댓글 apiController 수정
    - @RequestPart 사용 (@RequestBody 제거)
    - 응답 noContent()를 oK()로 수정 (성공했다는 의미로 ok로 변경) 
- 테스트코드
   - 바뀐 버전에 맞춰서 수정
- adoc 작성
    - board.adoc, comment.adoc, reply.adoc  
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️

## Issue numbers and link 🚪
Closes #76 
