### PR TITLE
[Feat] 유저 재고 목록 API를 구현한다

### DIFF
--- a/src/docs/asciidoc/business-product.adoc
+++ b/src/docs/asciidoc/business-product.adoc
@@ -1,0 +1,167 @@
+= BUSINESS PRODUCT 커넥트 제품 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+
+== ! API 호출 전 참고해야 할 쿼리스트링 입력값 !
+=== 1. condition
+|===
+|입력값
+
+|냉장
+|냉동
+|상온
+|===
+
+== 공통 예외
+=== 1. 권한이 없는 사용자가 BusinessProduct API를 호출한 경우 API 호출에 실패한다
+==== HTTP Request
+include::{snippets}/BusinessProductApi/CommonError/Case1/http-request.adoc[]
+Request Header
+include::{snippets}/BusinessProductApi/CommonError/Case1/request-headers.adoc[]
+Request Parameter
+include::{snippets}/BusinessProductApi/CommonError/Case1/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/BusinessProductApi/CommonError/Case1/http-response.adoc[]
+include::{snippets}/BusinessProductApi/CommonError/Case1/response-fields.adoc[]
+
+=== 2. 입력된 사용자가 요청한 사용자와 슈퍼바이저 - 사장님 관계가 아닌 경우 API 호출에 실패한다
+==== HTTP Request
+include::{snippets}/BusinessProductApi/CommonError/Case2/http-request.adoc[]
+Request Header
+include::{snippets}/BusinessProductApi/CommonError/Case2/request-headers.adoc[]
+Request Parameter
+include::{snippets}/BusinessProductApi/CommonError/Case2/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/BusinessProductApi/CommonError/Case2/http-response.adoc[]
+include::{snippets}/BusinessProductApi/CommonError/Case2/response-fields.adoc[]
+
+=== 3. 입력된 사용자가 유효하지 않은 역할을 가지고 있는 경우 API 호출에 실패한다
+==== HTTP Request
+include::{snippets}/BusinessProductApi/CommonError/Case3/http-request.adoc[]
+Request Header
+include::{snippets}/BusinessProductApi/CommonError/Case3/request-headers.adoc[]
+Request Parameter
+include::{snippets}/BusinessProductApi/CommonError/Case3/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/BusinessProductApi/CommonError/Case3/http-response.adoc[]
+include::{snippets}/BusinessProductApi/CommonError/Case3/response-fields.adoc[]
+
+=== 4. 입력된 사장님의 가게를 불러올 수 없는 경우 API 호출에 실패한다
+==== HTTP Request
+include::{snippets}/BusinessProductApi/CommonError/Case4/http-request.adoc[]
+Request Header
+include::{snippets}/BusinessProductApi/CommonError/Case4/request-headers.adoc[]
+Request Parameter
+include::{snippets}/BusinessProductApi/CommonError/Case4/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/BusinessProductApi/CommonError/Case4/http-response.adoc[]
+include::{snippets}/BusinessProductApi/CommonError/Case4/response-fields.adoc[]
+
+=== 5. 입력된 보관방법이 잘못된 경우 API 호출에 실패한다
+==== HTTP Request
+include::{snippets}/BusinessProductApi/CommonError/Case5/http-request.adoc[]
+Request Header
+include::{snippets}/BusinessProductApi/CommonError/Case5/request-headers.adoc[]
+Request Parameter
+include::{snippets}/BusinessProductApi/CommonError/Case5/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/BusinessProductApi/CommonError/Case5/http-response.adoc[]
+include::{snippets}/BusinessProductApi/CommonError/Case5/response-fields.adoc[]
+
+== 입력된 이름을 포함하는 모든 제품 목록 조회 (9.2.8)
+=== 1. 입력된 이름을 포함하는 제품이 존재하지 않을 경우 사장님 가게의 입력된 이름을 포함하는 모든 제품 목록 조회에 실패한다
+==== HTTP Request
+include::{snippets}/BusinessProductApi/GetProductOthersByName/Failure/Case1/http-request.adoc[]
+Request Header
+include::{snippets}/BusinessProductApi/GetProductOthersByName/Failure/Case1/request-headers.adoc[]
+Request Parameter
+include::{snippets}/BusinessProductApi/GetProductOthersByName/Failure/Case1/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/BusinessProductApi/GetProductOthersByName/Failure/Case1/http-response.adoc[]
+include::{snippets}/BusinessProductApi/GetProductOthersByName/Failure/Case1/response-fields.adoc[]
+
+=== 2. 사장님 가게의 입력된 이름을 포함하는 모든 제품 목록 조회에 성공한다
+==== HTTP Request
+include::{snippets}/BusinessProductApi/GetProductOthersByName/Success/http-request.adoc[]
+Request Header
+include::{snippets}/BusinessProductApi/GetProductOthersByName/Success/request-headers.adoc[]
+Request Parameter
+include::{snippets}/BusinessProductApi/GetProductOthersByName/Success/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/BusinessProductApi/GetProductOthersByName/Success/http-response.adoc[]
+include::{snippets}/BusinessProductApi/GetProductOthersByName/Success/response-fields.adoc[]
+
+== 사장님 가게의 분류 기준별 제품 개수 조회 (9.2, 와이어프레임 참고)
+=== 1. 사장님 가게의 분류 기준별 제품 개수 조회에 성공한다
+==== HTTP Request
+include::{snippets}/BusinessProductApi/GetTotal/Success/http-request.adoc[]
+Request Header
+include::{snippets}/BusinessProductApi/GetTotal/Success/request-headers.adoc[]
+Request Parameter
+include::{snippets}/BusinessProductApi/GetTotal/Success/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/BusinessProductApi/GetTotal/Success/http-response.adoc[]
+include::{snippets}/BusinessProductApi/GetTotal/Success/response-fields.adoc[]
+
+== 사장님 가게의 특정 정렬 기준을 만족하는 전체 제품 조회 (9.2.4)
+=== 1. 사장님 가게의 특정 정렬 기준을 만족하는 전체 제품 조회에 성공한다
+==== HTTP Request
+include::{snippets}/BusinessProductApi/GetAll/Success/http-request.adoc[]
+Request Header
+include::{snippets}/BusinessProductApi/GetAll/Success/request-headers.adoc[]
+Request Parameter
+include::{snippets}/BusinessProductApi/GetAll/Success/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/BusinessProductApi/GetAll/Success/http-response.adoc[]
+include::{snippets}/BusinessProductApi/GetAll/Success/response-fields.adoc[]
+
+== 사장님 가게의 특정 정렬 기준을 만족하는 유통기한 경과 제품 조회 (9.2.5)
+=== 1. 사장님 가게의 특정 정렬 기준을 만족하는 유통기한 경과 제품 조회에 성공한다
+==== HTTP Request
+include::{snippets}/BusinessProductApi/GetPass/Success/http-request.adoc[]
+Request Header
+include::{snippets}/BusinessProductApi/GetPass/Success/request-headers.adoc[]
+Request Parameter
+include::{snippets}/BusinessProductApi/GetPass/Success/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/BusinessProductApi/GetPass/Success/http-response.adoc[]
+include::{snippets}/BusinessProductApi/GetPass/Success/response-fields.adoc[]
+
+== 사장님 가게의 특정 정렬 기준을 만족하는 유통기한 임박 제품 조회 (9.2.6)
+=== 1. 사장님 가게의 특정 정렬 기준을 만족하는 유통기한 임박 제품 조회에 성공한다
+==== HTTP Request
+include::{snippets}/BusinessProductApi/GetClose/Success/http-request.adoc[]
+Request Header
+include::{snippets}/BusinessProductApi/GetClose/Success/request-headers.adoc[]
+Request Parameter
+include::{snippets}/BusinessProductApi/GetClose/Success/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/BusinessProductApi/GetClose/Success/http-response.adoc[]
+include::{snippets}/BusinessProductApi/GetClose/Success/response-fields.adoc[]
+
+== 사장님 가게의 특정 정렬 기준을 만족하는 재고 부족 제품 조회 (9.2.7)
+=== 1. 사장님 가게의 특정 정렬 기준을 만족하는 재고 부족 제품 조회에 성공한다
+==== HTTP Request
+include::{snippets}/BusinessProductApi/GetLack/Success/http-request.adoc[]
+Request Header
+include::{snippets}/BusinessProductApi/GetLack/Success/request-headers.adoc[]
+Request Parameter
+include::{snippets}/BusinessProductApi/GetLack/Success/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/BusinessProductApi/GetLack/Success/http-response.adoc[]
+include::{snippets}/BusinessProductApi/GetLack/Success/response-fields.adoc[]

--- a/src/docs/asciidoc/friend-product.adoc
+++ b/src/docs/asciidoc/friend-product.adoc
@@ -1,0 +1,167 @@
+= FRIEND PRODUCT 친구 제품 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+
+== ! API 호출 전 참고해야 할 쿼리스트링 입력값 !
+=== 1. condition
+|===
+|입력값
+
+|냉장
+|냉동
+|상온
+|===
+
+== 공통 예외
+=== 1. 권한이 없는 사용자가 FriendProduct API를 호출한 경우 API 호출에 실패한다
+==== HTTP Request
+include::{snippets}/FriendProductApi/CommonError/Case1/http-request.adoc[]
+Request Header
+include::{snippets}/FriendProductApi/CommonError/Case1/request-headers.adoc[]
+Request Parameter
+include::{snippets}/FriendProductApi/CommonError/Case1/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/FriendProductApi/CommonError/Case1/http-response.adoc[]
+include::{snippets}/FriendProductApi/CommonError/Case1/response-fields.adoc[]
+
+=== 2. 입력된 사용자가 요청한 사용자와 친구가 아닌 경우 API 호출에 실패한다
+==== HTTP Request
+include::{snippets}/FriendProductApi/CommonError/Case2/http-request.adoc[]
+Request Header
+include::{snippets}/FriendProductApi/CommonError/Case2/request-headers.adoc[]
+Request Parameter
+include::{snippets}/FriendProductApi/CommonError/Case2/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/FriendProductApi/CommonError/Case2/http-response.adoc[]
+include::{snippets}/FriendProductApi/CommonError/Case2/response-fields.adoc[]
+
+=== 3. 입력된 사용자가 유효하지 않은 역할을 가지고 있는 경우 API 호출에 실패한다
+==== HTTP Request
+include::{snippets}/FriendProductApi/CommonError/Case3/http-request.adoc[]
+Request Header
+include::{snippets}/FriendProductApi/CommonError/Case3/request-headers.adoc[]
+Request Parameter
+include::{snippets}/FriendProductApi/CommonError/Case3/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/FriendProductApi/CommonError/Case3/http-response.adoc[]
+include::{snippets}/FriendProductApi/CommonError/Case3/response-fields.adoc[]
+
+=== 4. 입력된 친구의 가게를 불러올 수 없는 경우 API 호출에 실패한다
+==== HTTP Request
+include::{snippets}/FriendProductApi/CommonError/Case4/http-request.adoc[]
+Request Header
+include::{snippets}/FriendProductApi/CommonError/Case4/request-headers.adoc[]
+Request Parameter
+include::{snippets}/FriendProductApi/CommonError/Case4/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/FriendProductApi/CommonError/Case4/http-response.adoc[]
+include::{snippets}/FriendProductApi/CommonError/Case4/response-fields.adoc[]
+
+=== 5. 입력된 보관방법이 잘못된 경우 API 호출에 실패한다
+==== HTTP Request
+include::{snippets}/FriendProductApi/CommonError/Case5/http-request.adoc[]
+Request Header
+include::{snippets}/FriendProductApi/CommonError/Case5/request-headers.adoc[]
+Request Parameter
+include::{snippets}/FriendProductApi/CommonError/Case5/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/FriendProductApi/CommonError/Case5/http-response.adoc[]
+include::{snippets}/FriendProductApi/CommonError/Case5/response-fields.adoc[]
+
+== 입력된 이름을 포함하는 모든 제품 목록 조회 (6.6.8)
+=== 1. 입력된 이름을 포함하는 제품이 존재하지 않을 경우 친구 가게의 입력된 이름을 포함하는 모든 제품 목록 조회에 실패한다
+==== HTTP Request
+include::{snippets}/FriendProductApi/GetProductOthersByName/Failure/Case1/http-request.adoc[]
+Request Header
+include::{snippets}/FriendProductApi/GetProductOthersByName/Failure/Case1/request-headers.adoc[]
+Request Parameter
+include::{snippets}/FriendProductApi/GetProductOthersByName/Failure/Case1/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/FriendProductApi/GetProductOthersByName/Failure/Case1/http-response.adoc[]
+include::{snippets}/FriendProductApi/GetProductOthersByName/Failure/Case1/response-fields.adoc[]
+
+=== 2. 친구 가게의 입력된 이름을 포함하는 모든 제품 목록 조회에 성공한다
+==== HTTP Request
+include::{snippets}/FriendProductApi/GetProductOthersByName/Success/http-request.adoc[]
+Request Header
+include::{snippets}/FriendProductApi/GetProductOthersByName/Success/request-headers.adoc[]
+Request Parameter
+include::{snippets}/FriendProductApi/GetProductOthersByName/Success/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/FriendProductApi/GetProductOthersByName/Success/http-response.adoc[]
+include::{snippets}/FriendProductApi/GetProductOthersByName/Success/response-fields.adoc[]
+
+== 친구 가게의 분류 기준별 제품 개수 조회 (6.6, 와이어프레임 참고)
+=== 1. 친구 가게의 분류 기준별 제품 개수 조회에 성공한다
+==== HTTP Request
+include::{snippets}/FriendProductApi/GetTotal/Success/http-request.adoc[]
+Request Header
+include::{snippets}/FriendProductApi/GetTotal/Success/request-headers.adoc[]
+Request Parameter
+include::{snippets}/FriendProductApi/GetTotal/Success/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/FriendProductApi/GetTotal/Success/http-response.adoc[]
+include::{snippets}/FriendProductApi/GetTotal/Success/response-fields.adoc[]
+
+== 친구 가게의 특정 정렬 기준을 만족하는 전체 제품 조회 (6.6.4)
+=== 1. 친구 가게의 특정 정렬 기준을 만족하는 전체 제품 조회에 성공한다
+==== HTTP Request
+include::{snippets}/FriendProductApi/GetAll/Success/http-request.adoc[]
+Request Header
+include::{snippets}/FriendProductApi/GetAll/Success/request-headers.adoc[]
+Request Parameter
+include::{snippets}/FriendProductApi/GetAll/Success/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/FriendProductApi/GetAll/Success/http-response.adoc[]
+include::{snippets}/FriendProductApi/GetAll/Success/response-fields.adoc[]
+
+== 친구 가게의 특정 정렬 기준을 만족하는 유통기한 경과 제품 조회 (6.6.5)
+=== 1. 친구 가게의 특정 정렬 기준을 만족하는 유통기한 경과 제품 조회에 성공한다
+==== HTTP Request
+include::{snippets}/FriendProductApi/GetPass/Success/http-request.adoc[]
+Request Header
+include::{snippets}/FriendProductApi/GetPass/Success/request-headers.adoc[]
+Request Parameter
+include::{snippets}/FriendProductApi/GetPass/Success/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/FriendProductApi/GetPass/Success/http-response.adoc[]
+include::{snippets}/FriendProductApi/GetPass/Success/response-fields.adoc[]
+
+== 친구 가게의 특정 정렬 기준을 만족하는 유통기한 임박 제품 조회 (6.6.6)
+=== 1. 친구 가게의 특정 정렬 기준을 만족하는 유통기한 임박 제품 조회에 성공한다
+==== HTTP Request
+include::{snippets}/FriendProductApi/GetClose/Success/http-request.adoc[]
+Request Header
+include::{snippets}/FriendProductApi/GetClose/Success/request-headers.adoc[]
+Request Parameter
+include::{snippets}/FriendProductApi/GetClose/Success/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/FriendProductApi/GetClose/Success/http-response.adoc[]
+include::{snippets}/FriendProductApi/GetClose/Success/response-fields.adoc[]
+
+== 친구 가게의 특정 정렬 기준을 만족하는 재고 부족 제품 조회 (6.6.7)
+=== 1. 친구 가게의 특정 정렬 기준을 만족하는 재고 부족 제품 조회에 성공한다
+==== HTTP Request
+include::{snippets}/FriendProductApi/GetLack/Success/http-request.adoc[]
+Request Header
+include::{snippets}/FriendProductApi/GetLack/Success/request-headers.adoc[]
+Request Parameter
+include::{snippets}/FriendProductApi/GetLack/Success/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/FriendProductApi/GetLack/Success/http-response.adoc[]
+include::{snippets}/FriendProductApi/GetLack/Success/response-fields.adoc[]

--- a/src/main/java/umc/stockoneqback/business/controller/BusinessProductApiController.java
+++ b/src/main/java/umc/stockoneqback/business/controller/BusinessProductApiController.java
@@ -1,0 +1,69 @@
+package umc.stockoneqback.business.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.stockoneqback.business.service.BusinessProductService;
+import umc.stockoneqback.global.annotation.ExtractPayload;
+import umc.stockoneqback.global.base.BaseResponse;
+import umc.stockoneqback.product.dto.response.GetTotalProductResponse;
+import umc.stockoneqback.product.dto.response.SearchProductOthersResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/business/product")
+public class BusinessProductApiController {
+    private BusinessProductService businessProductService;
+
+    @GetMapping("/search")
+    public BaseResponse<List<SearchProductOthersResponse>> searchProductOthers(@ExtractPayload Long supervisorId,
+                                                                               @RequestParam(value = "friend") Long managerId,
+                                                                               @RequestParam(value = "condition") String storeConditionValue,
+                                                                               @RequestParam(value = "name") String productName) throws IOException {
+        return new BaseResponse<>(businessProductService.searchProductOthers(supervisorId, managerId, storeConditionValue, productName));
+    }
+
+    @GetMapping("/count")
+    public BaseResponse<List<GetTotalProductResponse>> getTotalProductOthers(@ExtractPayload Long supervisorId,
+                                                                             @RequestParam(value = "friend") Long managerId,
+                                                                             @RequestParam(value = "condition") String storeConditionValue) throws IOException {
+        return new BaseResponse<>(businessProductService.getTotalProductOthers(supervisorId, managerId, storeConditionValue));
+    }
+
+    @GetMapping("/all")
+    public BaseResponse<List<SearchProductOthersResponse>> getListOfAllProductOthers(@ExtractPayload Long supervisorId,
+                                                                                     @RequestParam(value = "friend") Long managerId,
+                                                                                     @RequestParam(value = "condition") String storeConditionValue,
+                                                                                     @RequestParam(value = "last", required = false) Long productId) throws IOException {
+        return new BaseResponse<>(businessProductService.getListOfCategoryProductOthers(supervisorId, managerId, storeConditionValue, productId, "All"));
+    }
+
+    @GetMapping("/pass")
+    public BaseResponse<List<SearchProductOthersResponse>> getListOfPassProductOthers(@ExtractPayload Long supervisorId,
+                                                                                      @RequestParam(value = "friend") Long managerId,
+                                                                                      @RequestParam(value = "condition") String storeConditionValue,
+                                                                                      @RequestParam(value = "last", required = false) Long productId) throws IOException {
+        return new BaseResponse<>(businessProductService.getListOfCategoryProductOthers(supervisorId, managerId, storeConditionValue, productId, "Pass"));
+    }
+
+    @GetMapping("/close")
+    public BaseResponse<List<SearchProductOthersResponse>> getListOfCloseProductOthers(@ExtractPayload Long supervisorId,
+                                                                                       @RequestParam(value = "friend") Long managerId,
+                                                                                       @RequestParam(value = "condition") String storeConditionValue,
+                                                                                       @RequestParam(value = "last", required = false) Long productId) throws IOException {
+        return new BaseResponse<>(businessProductService.getListOfCategoryProductOthers(supervisorId, managerId, storeConditionValue, productId, "Close"));
+    }
+
+    @GetMapping("/lack")
+    public BaseResponse<List<SearchProductOthersResponse>> getListOfLackProductOthers(@ExtractPayload Long supervisorId,
+                                                                                      @RequestParam(value = "friend") Long managerId,
+                                                                                      @RequestParam(value = "condition") String storeConditionValue,
+                                                                                      @RequestParam(value = "last", required = false) Long productId) throws IOException {
+        return new BaseResponse<>(businessProductService.getListOfCategoryProductOthers(supervisorId, managerId, storeConditionValue, productId, "Lack"));
+    }
+}

--- a/src/main/java/umc/stockoneqback/business/controller/BusinessProductApiController.java
+++ b/src/main/java/umc/stockoneqback/business/controller/BusinessProductApiController.java
@@ -22,7 +22,7 @@ public class BusinessProductApiController {
 
     @GetMapping("/search")
     public BaseResponse<List<SearchProductOthersResponse>> searchProductOthers(@ExtractPayload Long supervisorId,
-                                                                               @RequestParam(value = "friend") Long managerId,
+                                                                               @RequestParam(value = "manager") Long managerId,
                                                                                @RequestParam(value = "condition") String storeConditionValue,
                                                                                @RequestParam(value = "name") String productName) throws IOException {
         return new BaseResponse<>(businessProductService.searchProductOthers(supervisorId, managerId, storeConditionValue, productName));
@@ -30,14 +30,14 @@ public class BusinessProductApiController {
 
     @GetMapping("/count")
     public BaseResponse<List<GetTotalProductResponse>> getTotalProductOthers(@ExtractPayload Long supervisorId,
-                                                                             @RequestParam(value = "friend") Long managerId,
+                                                                             @RequestParam(value = "manager") Long managerId,
                                                                              @RequestParam(value = "condition") String storeConditionValue) throws IOException {
         return new BaseResponse<>(businessProductService.getTotalProductOthers(supervisorId, managerId, storeConditionValue));
     }
 
     @GetMapping("/all")
     public BaseResponse<List<SearchProductOthersResponse>> getListOfAllProductOthers(@ExtractPayload Long supervisorId,
-                                                                                     @RequestParam(value = "friend") Long managerId,
+                                                                                     @RequestParam(value = "manager") Long managerId,
                                                                                      @RequestParam(value = "condition") String storeConditionValue,
                                                                                      @RequestParam(value = "last", required = false) Long productId) throws IOException {
         return new BaseResponse<>(businessProductService.getListOfCategoryProductOthers(supervisorId, managerId, storeConditionValue, productId, "All"));
@@ -45,7 +45,7 @@ public class BusinessProductApiController {
 
     @GetMapping("/pass")
     public BaseResponse<List<SearchProductOthersResponse>> getListOfPassProductOthers(@ExtractPayload Long supervisorId,
-                                                                                      @RequestParam(value = "friend") Long managerId,
+                                                                                      @RequestParam(value = "manager") Long managerId,
                                                                                       @RequestParam(value = "condition") String storeConditionValue,
                                                                                       @RequestParam(value = "last", required = false) Long productId) throws IOException {
         return new BaseResponse<>(businessProductService.getListOfCategoryProductOthers(supervisorId, managerId, storeConditionValue, productId, "Pass"));
@@ -53,7 +53,7 @@ public class BusinessProductApiController {
 
     @GetMapping("/close")
     public BaseResponse<List<SearchProductOthersResponse>> getListOfCloseProductOthers(@ExtractPayload Long supervisorId,
-                                                                                       @RequestParam(value = "friend") Long managerId,
+                                                                                       @RequestParam(value = "manager") Long managerId,
                                                                                        @RequestParam(value = "condition") String storeConditionValue,
                                                                                        @RequestParam(value = "last", required = false) Long productId) throws IOException {
         return new BaseResponse<>(businessProductService.getListOfCategoryProductOthers(supervisorId, managerId, storeConditionValue, productId, "Close"));
@@ -61,7 +61,7 @@ public class BusinessProductApiController {
 
     @GetMapping("/lack")
     public BaseResponse<List<SearchProductOthersResponse>> getListOfLackProductOthers(@ExtractPayload Long supervisorId,
-                                                                                      @RequestParam(value = "friend") Long managerId,
+                                                                                      @RequestParam(value = "manager") Long managerId,
                                                                                       @RequestParam(value = "condition") String storeConditionValue,
                                                                                       @RequestParam(value = "last", required = false) Long productId) throws IOException {
         return new BaseResponse<>(businessProductService.getListOfCategoryProductOthers(supervisorId, managerId, storeConditionValue, productId, "Lack"));

--- a/src/main/java/umc/stockoneqback/business/controller/BusinessProductApiController.java
+++ b/src/main/java/umc/stockoneqback/business/controller/BusinessProductApiController.java
@@ -18,7 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/business/product")
 public class BusinessProductApiController {
-    private BusinessProductService businessProductService;
+    private final BusinessProductService businessProductService;
 
     @GetMapping("/search")
     public BaseResponse<List<SearchProductOthersResponse>> searchProductOthers(@ExtractPayload Long supervisorId,

--- a/src/main/java/umc/stockoneqback/business/service/BusinessProductService.java
+++ b/src/main/java/umc/stockoneqback/business/service/BusinessProductService.java
@@ -1,6 +1,9 @@
 package umc.stockoneqback.business.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.global.base.GlobalErrorCode;
 import umc.stockoneqback.product.dto.response.SearchProductOthersResponse;
 import umc.stockoneqback.global.base.BaseException;
 import umc.stockoneqback.product.dto.response.GetTotalProductResponse;
@@ -8,12 +11,18 @@ import umc.stockoneqback.product.exception.ProductErrorCode;
 import umc.stockoneqback.product.service.ProductOthersService;
 import umc.stockoneqback.role.domain.store.Store;
 import umc.stockoneqback.role.service.StoreService;
+import umc.stockoneqback.user.domain.Role;
 import umc.stockoneqback.user.domain.User;
+import umc.stockoneqback.user.exception.UserErrorCode;
 import umc.stockoneqback.user.service.UserFindService;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class BusinessProductService {
     private UserFindService userFindService;
     private StoreService storeService;
@@ -23,7 +32,8 @@ public class BusinessProductService {
     @Transactional
     public List<SearchProductOthersResponse> searchProductOthers
             (Long supervisorId, Long managerId, String storeConditionValue, String productName) throws IOException {
-        User manager = checkRelation(supervisorId, managerId);
+        User supervisor = isSupervisor(supervisorId);
+        User manager = checkRelation(supervisor, managerId);
         Store managerStore = storeService.findByUser(manager);
         return productOthersService.searchProductOthers(managerStore, storeConditionValue, productName);
     }
@@ -31,7 +41,8 @@ public class BusinessProductService {
     @Transactional
     public List<GetTotalProductResponse> getTotalProductOthers
             (Long supervisorId, Long managerId, String storeConditionValue) throws IOException {
-        User manager = checkRelation(supervisorId, managerId);
+        User supervisor = isSupervisor(supervisorId);
+        User manager = checkRelation(supervisor, managerId);
         Store managerStore = storeService.findByUser(manager);
         return productOthersService.getTotalProductOthers(managerStore, storeConditionValue);
     }
@@ -39,7 +50,8 @@ public class BusinessProductService {
     @Transactional
     public List<SearchProductOthersResponse> getListOfCategoryProductOthers
             (Long supervisorId, Long managerId, String storeConditionValue, Long productId, String category) throws IOException {
-        User manager = checkRelation(supervisorId, managerId);
+        User supervisor = isSupervisor(supervisorId);
+        User manager = checkRelation(supervisor, managerId);
         Store managerStore = storeService.findByUser(manager);
         switch (category) {
             case "All" -> {
@@ -58,8 +70,16 @@ public class BusinessProductService {
         throw BaseException.type(ProductErrorCode.NOT_FOUND_CATEGORY);
     }
 
-    private User checkRelation(Long supervisorId, Long managerId) {
-        User supervisor = userFindService.findById(supervisorId);
+    private User isSupervisor(Long userId) {
+        User user = userFindService.findById(userId);
+        if (user.getRole() == Role.SUPERVISOR)
+            return user;
+        if (Arrays.stream(Role.values()).anyMatch(role -> role.equals(user.getRole())))
+            throw BaseException.type(GlobalErrorCode.INVALID_USER_JWT);
+        throw BaseException.type(UserErrorCode.ROLE_NOT_FOUND);
+    }
+
+    private User checkRelation(User supervisor, Long managerId) {
         User manager = userFindService.findById(managerId);
         businessService.validateNotExist(supervisor, manager);
         return manager;

--- a/src/main/java/umc/stockoneqback/business/service/BusinessProductService.java
+++ b/src/main/java/umc/stockoneqback/business/service/BusinessProductService.java
@@ -1,0 +1,67 @@
+package umc.stockoneqback.business.service;
+
+import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.product.dto.response.SearchProductOthersResponse;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.product.dto.response.GetTotalProductResponse;
+import umc.stockoneqback.product.exception.ProductErrorCode;
+import umc.stockoneqback.product.service.ProductOthersService;
+import umc.stockoneqback.role.domain.store.Store;
+import umc.stockoneqback.role.service.StoreService;
+import umc.stockoneqback.user.domain.User;
+import umc.stockoneqback.user.service.UserFindService;
+
+import java.io.IOException;
+import java.util.List;
+
+public class BusinessProductService {
+    private UserFindService userFindService;
+    private StoreService storeService;
+    private ProductOthersService productOthersService;
+    private BusinessService businessService;
+
+    @Transactional
+    public List<SearchProductOthersResponse> searchProductOthers
+            (Long supervisorId, Long managerId, String storeConditionValue, String productName) throws IOException {
+        User manager = checkRelation(supervisorId, managerId);
+        Store managerStore = storeService.findByUser(manager);
+        return productOthersService.searchProductOthers(managerStore, storeConditionValue, productName);
+    }
+
+    @Transactional
+    public List<GetTotalProductResponse> getTotalProductOthers
+            (Long supervisorId, Long managerId, String storeConditionValue) throws IOException {
+        User manager = checkRelation(supervisorId, managerId);
+        Store managerStore = storeService.findByUser(manager);
+        return productOthersService.getTotalProductOthers(managerStore, storeConditionValue);
+    }
+
+    @Transactional
+    public List<SearchProductOthersResponse> getListOfCategoryProductOthers
+            (Long supervisorId, Long managerId, String storeConditionValue, Long productId, String category) throws IOException {
+        User manager = checkRelation(supervisorId, managerId);
+        Store managerStore = storeService.findByUser(manager);
+        switch (category) {
+            case "All" -> {
+                return productOthersService.getListOfAllProductOthers(managerStore, storeConditionValue, productId);
+            }
+            case "Pass" -> {
+                return productOthersService.getListOfPassProductOthers(managerStore, storeConditionValue, productId);
+            }
+            case "Close" -> {
+                return productOthersService.getListOfCloseProductOthers(managerStore, storeConditionValue, productId);
+            }
+            case "Lack" -> {
+                return productOthersService.getListOfLackProductOthers(managerStore, storeConditionValue, productId);
+            }
+        }
+        throw BaseException.type(ProductErrorCode.NOT_FOUND_CATEGORY);
+    }
+
+    private User checkRelation(Long supervisorId, Long managerId) {
+        User supervisor = userFindService.findById(supervisorId);
+        User manager = userFindService.findById(managerId);
+        businessService.validateNotExist(supervisor, manager);
+        return manager;
+    }
+}

--- a/src/main/java/umc/stockoneqback/business/service/BusinessService.java
+++ b/src/main/java/umc/stockoneqback/business/service/BusinessService.java
@@ -43,7 +43,7 @@ public class BusinessService {
         businessRepository.deleteBySupervisorAndManager(supervisor, manager);
     }
 
-    private void validateNotExist(User supervisor, User manager) {
+    void validateNotExist(User supervisor, User manager) {
         if (!businessRepository.existsBySupervisorAndManager(supervisor, manager)) {
             throw BaseException.type(BusinessErrorCode.BUSINESS_NOT_FOUND);
         }

--- a/src/main/java/umc/stockoneqback/friend/controller/FriendProductApiController.java
+++ b/src/main/java/umc/stockoneqback/friend/controller/FriendProductApiController.java
@@ -1,0 +1,69 @@
+package umc.stockoneqback.friend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.stockoneqback.friend.service.FriendProductService;
+import umc.stockoneqback.product.dto.response.SearchProductOthersResponse;
+import umc.stockoneqback.global.annotation.ExtractPayload;
+import umc.stockoneqback.global.base.BaseResponse;
+import umc.stockoneqback.product.dto.response.GetTotalProductResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/friend/product")
+public class FriendProductApiController {
+    private FriendProductService friendProductService;
+
+    @GetMapping("/search")
+    public BaseResponse<List<SearchProductOthersResponse>> searchProductOthers(@ExtractPayload Long userId,
+                                                                                  @RequestParam(value = "friend") Long friendId,
+                                                                                  @RequestParam(value = "condition") String storeConditionValue,
+                                                                                  @RequestParam(value = "name") String productName) throws IOException {
+        return new BaseResponse<>(friendProductService.searchProductOthers(userId, friendId, storeConditionValue, productName));
+    }
+
+    @GetMapping("/count")
+    public BaseResponse<List<GetTotalProductResponse>> getTotalProductOthers(@ExtractPayload Long userId,
+                                                                             @RequestParam(value = "friend") Long friendId,
+                                                                       @RequestParam(value = "condition") String storeConditionValue) throws IOException {
+        return new BaseResponse<>(friendProductService.getTotalProductOthers(userId, friendId, storeConditionValue));
+    }
+
+    @GetMapping("/all")
+    public BaseResponse<List<SearchProductOthersResponse>> getListOfAllProductOthers(@ExtractPayload Long userId,
+                                                                               @RequestParam(value = "friend") Long friendId,
+                                                                         @RequestParam(value = "condition") String storeConditionValue,
+                                                                         @RequestParam(value = "last", required = false) Long productId) throws IOException {
+        return new BaseResponse<>(friendProductService.getListOfCategoryProductOthers(userId, friendId, storeConditionValue, productId, "All"));
+    }
+
+    @GetMapping("/pass")
+    public BaseResponse<List<SearchProductOthersResponse>> getListOfPassProductOthers(@ExtractPayload Long userId,
+                                                                                @RequestParam(value = "friend") Long friendId,
+                                                                                @RequestParam(value = "condition") String storeConditionValue,
+                                                                                @RequestParam(value = "last", required = false) Long productId) throws IOException {
+        return new BaseResponse<>(friendProductService.getListOfCategoryProductOthers(userId, friendId, storeConditionValue, productId, "Pass"));
+    }
+
+    @GetMapping("/close")
+    public BaseResponse<List<SearchProductOthersResponse>> getListOfCloseProductOthers(@ExtractPayload Long userId,
+                                                                                 @RequestParam(value = "friend") Long friendId,
+                                                                                 @RequestParam(value = "condition") String storeConditionValue,
+                                                                                 @RequestParam(value = "last", required = false) Long productId) throws IOException {
+        return new BaseResponse<>(friendProductService.getListOfCategoryProductOthers(userId, friendId, storeConditionValue, productId, "Close"));
+    }
+
+    @GetMapping("/lack")
+    public BaseResponse<List<SearchProductOthersResponse>> getListOfLackProductOthers(@ExtractPayload Long userId,
+                                                                                @RequestParam(value = "friend") Long friendId,
+                                                                                @RequestParam(value = "condition") String storeConditionValue,
+                                                                                @RequestParam(value = "last", required = false) Long productId) throws IOException {
+        return new BaseResponse<>(friendProductService.getListOfCategoryProductOthers(userId, friendId, storeConditionValue, productId, "Lack"));
+    }
+}

--- a/src/main/java/umc/stockoneqback/friend/controller/FriendProductApiController.java
+++ b/src/main/java/umc/stockoneqback/friend/controller/FriendProductApiController.java
@@ -18,7 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/friend/product")
 public class FriendProductApiController {
-    private FriendProductService friendProductService;
+    private final FriendProductService friendProductService;
 
     @GetMapping("/search")
     public BaseResponse<List<SearchProductOthersResponse>> searchProductOthers(@ExtractPayload Long userId,

--- a/src/main/java/umc/stockoneqback/friend/service/FriendProductService.java
+++ b/src/main/java/umc/stockoneqback/friend/service/FriendProductService.java
@@ -1,6 +1,9 @@
 package umc.stockoneqback.friend.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.global.base.GlobalErrorCode;
 import umc.stockoneqback.product.dto.response.SearchProductOthersResponse;
 import umc.stockoneqback.global.base.BaseException;
 import umc.stockoneqback.product.dto.response.GetTotalProductResponse;
@@ -8,12 +11,18 @@ import umc.stockoneqback.product.exception.ProductErrorCode;
 import umc.stockoneqback.product.service.ProductOthersService;
 import umc.stockoneqback.role.domain.store.Store;
 import umc.stockoneqback.role.service.StoreService;
+import umc.stockoneqback.user.domain.Role;
 import umc.stockoneqback.user.domain.User;
+import umc.stockoneqback.user.exception.UserErrorCode;
 import umc.stockoneqback.user.service.UserFindService;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class FriendProductService {
     private UserFindService userFindService;
     private StoreService storeService;
@@ -23,7 +32,8 @@ public class FriendProductService {
     @Transactional
     public List<SearchProductOthersResponse> searchProductOthers
             (Long userId, Long friendId, String storeConditionValue, String productName) throws IOException {
-        User friend = checkRelation(userId, friendId);
+        User manager = isManager(userId);
+        User friend = checkRelation(manager, friendId);
         Store friendStore = storeService.findByUser(friend);
         return productOthersService.searchProductOthers(friendStore, storeConditionValue, productName);
     }
@@ -31,7 +41,8 @@ public class FriendProductService {
     @Transactional
     public List<GetTotalProductResponse> getTotalProductOthers
             (Long userId, Long friendId, String storeConditionValue) throws IOException {
-        User friend = checkRelation(userId, friendId);
+        User manager = isManager(userId);
+        User friend = checkRelation(manager, friendId);
         Store friendStore = storeService.findByUser(friend);
         return productOthersService.getTotalProductOthers(friendStore, storeConditionValue);
     }
@@ -39,7 +50,8 @@ public class FriendProductService {
     @Transactional
     public List<SearchProductOthersResponse> getListOfCategoryProductOthers
             (Long userId, Long friendId, String storeConditionValue, Long productId, String category) throws IOException {
-        User friend = checkRelation(userId, friendId);
+        User manager = isManager(userId);
+        User friend = checkRelation(manager, friendId);
         Store friendStore = storeService.findByUser(friend);
         switch (category) {
             case "All" -> {
@@ -58,8 +70,16 @@ public class FriendProductService {
         throw BaseException.type(ProductErrorCode.NOT_FOUND_CATEGORY);
     }
 
-    private User checkRelation(Long userId, Long friendId) {
+    private User isManager(Long userId) {
         User user = userFindService.findById(userId);
+        if (user.getRole() == Role.MANAGER)
+            return user;
+        if (Arrays.stream(Role.values()).anyMatch(role -> role.equals(user.getRole())))
+            throw BaseException.type(GlobalErrorCode.INVALID_USER_JWT);
+        throw BaseException.type(UserErrorCode.ROLE_NOT_FOUND);
+    }
+
+    private User checkRelation(User user, Long friendId) {
         User friend = userFindService.findById(friendId);
         friendService.validateNotFriend(user, friend);
         return friend;

--- a/src/main/java/umc/stockoneqback/friend/service/FriendProductService.java
+++ b/src/main/java/umc/stockoneqback/friend/service/FriendProductService.java
@@ -1,0 +1,67 @@
+package umc.stockoneqback.friend.service;
+
+import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.product.dto.response.SearchProductOthersResponse;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.product.dto.response.GetTotalProductResponse;
+import umc.stockoneqback.product.exception.ProductErrorCode;
+import umc.stockoneqback.product.service.ProductOthersService;
+import umc.stockoneqback.role.domain.store.Store;
+import umc.stockoneqback.role.service.StoreService;
+import umc.stockoneqback.user.domain.User;
+import umc.stockoneqback.user.service.UserFindService;
+
+import java.io.IOException;
+import java.util.List;
+
+public class FriendProductService {
+    private UserFindService userFindService;
+    private StoreService storeService;
+    private ProductOthersService productOthersService;
+    private FriendService friendService;
+
+    @Transactional
+    public List<SearchProductOthersResponse> searchProductOthers
+            (Long userId, Long friendId, String storeConditionValue, String productName) throws IOException {
+        User friend = checkRelation(userId, friendId);
+        Store friendStore = storeService.findByUser(friend);
+        return productOthersService.searchProductOthers(friendStore, storeConditionValue, productName);
+    }
+
+    @Transactional
+    public List<GetTotalProductResponse> getTotalProductOthers
+            (Long userId, Long friendId, String storeConditionValue) throws IOException {
+        User friend = checkRelation(userId, friendId);
+        Store friendStore = storeService.findByUser(friend);
+        return productOthersService.getTotalProductOthers(friendStore, storeConditionValue);
+    }
+
+    @Transactional
+    public List<SearchProductOthersResponse> getListOfCategoryProductOthers
+            (Long userId, Long friendId, String storeConditionValue, Long productId, String category) throws IOException {
+        User friend = checkRelation(userId, friendId);
+        Store friendStore = storeService.findByUser(friend);
+        switch (category) {
+            case "All" -> {
+                return productOthersService.getListOfAllProductOthers(friendStore, storeConditionValue, productId);
+            }
+            case "Pass" -> {
+                return productOthersService.getListOfPassProductOthers(friendStore, storeConditionValue, productId);
+            }
+            case "Close" -> {
+                return productOthersService.getListOfCloseProductOthers(friendStore, storeConditionValue, productId);
+            }
+            case "Lack" -> {
+                return productOthersService.getListOfLackProductOthers(friendStore, storeConditionValue, productId);
+            }
+        }
+        throw BaseException.type(ProductErrorCode.NOT_FOUND_CATEGORY);
+    }
+
+    private User checkRelation(Long userId, Long friendId) {
+        User user = userFindService.findById(userId);
+        User friend = userFindService.findById(friendId);
+        friendService.validateNotFriend(user, friend);
+        return friend;
+    }
+}

--- a/src/main/java/umc/stockoneqback/friend/service/FriendService.java
+++ b/src/main/java/umc/stockoneqback/friend/service/FriendService.java
@@ -97,4 +97,10 @@ public class FriendService {
             throw BaseException.type(FriendErrorCode.STATUS_IS_REQUEST);
         }
     }
+
+    void validateNotFriend(User sender, User receiver) {
+        if (!friendRepository.existsBySenderAndReceiver(sender, receiver) && !friendRepository.existsBySenderAndReceiver(receiver, sender)) {
+            throw BaseException.type(FriendErrorCode.FRIEND_NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/umc/stockoneqback/product/domain/ProductRepository.java
+++ b/src/main/java/umc/stockoneqback/product/domain/ProductRepository.java
@@ -124,12 +124,12 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
                                                          @Param("pageSize") Integer pageSize);
 
     @Query(value = "SELECT p.name FROM product p WHERE p.status = '정상' AND p.expiration_date < :currentDate AND " +
-            "p.store = (SELECT s.id FROM store s WHERE s.manager_id = :manager)", nativeQuery = true)
+            "p.store = (SELECT s.id FROM store s WHERE s.manager_id = :manager) ORDER BY p.name", nativeQuery = true)
     List<String> findPassByManager(@Param("manager") User user,
                                    @Param("currentDate") LocalDate currentDate);
 
     @Query(value = "SELECT p.name FROM product p WHERE p.status = '정상' AND p.expiration_date < :currentDate AND " +
-            "p.store = (SELECT t.store_id FROM part_timer t WHERE t.part_timer_id = :partTimer)", nativeQuery = true)
+            "p.store = (SELECT t.store_id FROM part_timer t WHERE t.part_timer_id = :partTimer) ORDER BY p.name", nativeQuery = true)
     List<String> findPassByPartTimer(@Param("partTimer") User user,
                                      @Param("currentDate") LocalDate currentDate);
 }

--- a/src/main/java/umc/stockoneqback/product/dto/response/SearchProductOthersResponse.java
+++ b/src/main/java/umc/stockoneqback/product/dto/response/SearchProductOthersResponse.java
@@ -1,0 +1,15 @@
+package umc.stockoneqback.product.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record SearchProductOthersResponse(
+        Long id,
+
+        String name,
+
+        Long stockQuant,
+
+        byte[] image
+) {
+}

--- a/src/main/java/umc/stockoneqback/product/exception/ProductErrorCode.java
+++ b/src/main/java/umc/stockoneqback/product/exception/ProductErrorCode.java
@@ -11,7 +11,9 @@ public enum ProductErrorCode implements ErrorCode {
     NOT_FOUND_PRODUCT(HttpStatus.NOT_FOUND, "PRODUCT_001", "입력값에 해당하는 제품이 없습니다."),
     DUPLICATE_PRODUCT(HttpStatus.CONFLICT, "PRODUCT_002", "입력한 제품과 동일한 제품명이 존재합니다."),
     NOT_FOUND_STORE_CONDITION(HttpStatus.NOT_FOUND, "PRODUCT_003", "입력값에 해당하는 보관방법이 없습니다."),
-    NOT_FOUND_SORT_CONDITION(HttpStatus.NOT_FOUND, "PRODUCT_004", "입력값에 해당하는 정렬 방식이 없습니다.");
+    NOT_FOUND_SORT_CONDITION(HttpStatus.NOT_FOUND, "PRODUCT_004", "입력값에 해당하는 정렬 방식이 없습니다."),
+    NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "PRODUCT_005", "입력값에 해당하는 제품 분류 카테고리가 없습니다."),
+    ;
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/umc/stockoneqback/product/service/ProductOthersService.java
+++ b/src/main/java/umc/stockoneqback/product/service/ProductOthersService.java
@@ -9,7 +9,6 @@ import umc.stockoneqback.product.domain.StoreCondition;
 import umc.stockoneqback.product.dto.response.GetTotalProductResponse;
 import umc.stockoneqback.product.dto.response.SearchProductOthersResponse;
 import umc.stockoneqback.role.domain.store.Store;
-import umc.stockoneqback.role.service.StoreService;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -22,7 +21,6 @@ import java.util.List;
 public class ProductOthersService {
     private final ProductRepository productRepository;
     private final ProductService productService;
-    private final StoreService storeService;
     private static final Integer PAGE_SIZE = 9;
 
     @Transactional

--- a/src/main/java/umc/stockoneqback/product/service/ProductOthersService.java
+++ b/src/main/java/umc/stockoneqback/product/service/ProductOthersService.java
@@ -1,0 +1,99 @@
+package umc.stockoneqback.product.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.product.domain.Product;
+import umc.stockoneqback.product.domain.ProductRepository;
+import umc.stockoneqback.product.domain.StoreCondition;
+import umc.stockoneqback.product.dto.response.GetTotalProductResponse;
+import umc.stockoneqback.product.dto.response.SearchProductOthersResponse;
+import umc.stockoneqback.role.domain.store.Store;
+import umc.stockoneqback.role.service.StoreService;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProductOthersService {
+    private final ProductRepository productRepository;
+    private final ProductService productService;
+    private final StoreService storeService;
+    private static final Integer PAGE_SIZE = 9;
+
+    @Transactional
+    public List<SearchProductOthersResponse> searchProductOthers
+            (Store store, String storeConditionValue, String productName) throws IOException {
+        StoreCondition storeCondition = StoreCondition.findStoreConditionByValue(storeConditionValue);
+        List<Product> searchProductUrlList = productService.findProductAllByName(store, storeCondition, productName);
+        return convertUrlToResponse(searchProductUrlList);
+    }
+
+    @Transactional
+    public List<GetTotalProductResponse> getTotalProductOthers(Store store, String storeConditionValue) {
+        StoreCondition storeCondition = StoreCondition.findStoreConditionByValue(storeConditionValue);
+        return productService.countProduct(store, storeCondition);
+    }
+
+    @Transactional
+    public List<SearchProductOthersResponse> getListOfAllProductOthers
+            (Store store, String storeConditionValue, Long productId) throws IOException {
+        Product product = productService.configPaging(productId);
+        StoreCondition storeCondition = StoreCondition.findStoreConditionByValue(storeConditionValue);
+        List<Product> searchProductUrlList = productRepository.findPageOfAllOrderByName
+                (store, storeCondition.getValue(), product.getName(), PAGE_SIZE);
+        return convertUrlToResponse(searchProductUrlList);
+    }
+
+    @Transactional
+    public List<SearchProductOthersResponse> getListOfPassProductOthers
+            (Store store, String storeConditionValue, Long productId) throws IOException {
+        Product product = productService.configPaging(productId);
+        StoreCondition storeCondition = StoreCondition.findStoreConditionByValue(storeConditionValue);
+        LocalDate currentDate = LocalDate.now();
+        List<Product> searchProductUrlList = productRepository.findPageOfPassOrderByName
+                (store, storeCondition.getValue(), product.getName(), PAGE_SIZE, currentDate);
+        return convertUrlToResponse(searchProductUrlList);
+    }
+
+    @Transactional
+    public List<SearchProductOthersResponse> getListOfCloseProductOthers
+            (Store store, String storeConditionValue, Long productId) throws IOException {
+        Product product = productService.configPaging(productId);
+        StoreCondition storeCondition = StoreCondition.findStoreConditionByValue(storeConditionValue);
+        LocalDate currentDate = LocalDate.now();
+        LocalDate standardDate = currentDate.plusDays(3);
+        List<Product> searchProductUrlList = productRepository.findPageOfCloseOrderByName
+                (store, storeCondition.getValue(), product.getName(), PAGE_SIZE, currentDate, standardDate);
+        return convertUrlToResponse(searchProductUrlList);
+    }
+
+    @Transactional
+    public List<SearchProductOthersResponse> getListOfLackProductOthers
+            (Store store, String storeConditionValue, Long productId) throws IOException {
+        Product product = productService.configPaging(productId);
+        StoreCondition storeCondition = StoreCondition.findStoreConditionByValue(storeConditionValue);
+        List<Product> searchProductUrlList = productRepository.findPageOfLackOrderByName
+                (store, storeCondition.getValue(), product.getName(), PAGE_SIZE);
+        return convertUrlToResponse(searchProductUrlList);
+    }
+
+    private List<SearchProductOthersResponse> convertUrlToResponse(List<Product> searchProductUrlList) throws IOException {
+        List<SearchProductOthersResponse> searchProductOthersResponseList = new ArrayList<>();
+        for (Product searchProductUrl : searchProductUrlList) {
+            byte[] image = productService.getImageOrElseNull(searchProductUrl.getImageUrl());
+            SearchProductOthersResponse searchProductOthersResponse = SearchProductOthersResponse.builder()
+                    .id(searchProductUrl.getId())
+                    .name(searchProductUrl.getName())
+                    .stockQuant(searchProductUrl.getStockQuant())
+                    .image(image)
+                    .build();
+            searchProductOthersResponseList.add(searchProductOthersResponse);
+        }
+        return searchProductOthersResponseList;
+    }
+}

--- a/src/main/java/umc/stockoneqback/product/service/ProductService.java
+++ b/src/main/java/umc/stockoneqback/product/service/ProductService.java
@@ -243,7 +243,7 @@ public class ProductService {
             throw BaseException.type(ProductErrorCode.DUPLICATE_PRODUCT);
     }
 
-    private List<Product> findProductAllByName(Store store, StoreCondition storeCondition, String productName) {
+    List<Product> findProductAllByName(Store store, StoreCondition storeCondition, String productName) {
         List<Product> searchProductUrlList = productRepository.findProductByName(store, storeCondition.getValue(), productName);
         if (searchProductUrlList.isEmpty())
             throw BaseException.type(ProductErrorCode.NOT_FOUND_PRODUCT);
@@ -255,7 +255,7 @@ public class ProductService {
                 .orElseThrow(() -> BaseException.type(ProductErrorCode.NOT_FOUND_PRODUCT));
     }
 
-    private List<GetTotalProductResponse> countProduct(Store store, StoreCondition storeCondition) {
+    List<GetTotalProductResponse> countProduct(Store store, StoreCondition storeCondition) {
         List<GetTotalProductResponse> countList = new ArrayList<>(4);
         LocalDate currentDate = LocalDate.now();
         LocalDate standardDate = currentDate.plusDays(3);
@@ -270,7 +270,7 @@ public class ProductService {
         return countList;
     }
 
-    private Product configPaging(Long productId) {
+    Product configPaging(Long productId) {
         if (productId == null)
             return new Product();
         return findProductById(productId);
@@ -290,7 +290,7 @@ public class ProductService {
         return searchProductResponseList;
     }
 
-    private byte[] getImageOrElseNull(String imageUrl) throws IOException {
+    byte[] getImageOrElseNull(String imageUrl) throws IOException {
         if (imageUrl == null)
             return null;
         return fileService.downloadToResponseDto(imageUrl);

--- a/src/test/java/umc/stockoneqback/business/controller/BusinessProductApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/business/controller/BusinessProductApiControllerTest.java
@@ -1,0 +1,839 @@
+package umc.stockoneqback.business.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import umc.stockoneqback.business.exception.BusinessErrorCode;
+import umc.stockoneqback.common.ControllerTest;
+import umc.stockoneqback.fixture.ProductFixture;
+import umc.stockoneqback.friend.exception.FriendErrorCode;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.global.base.GlobalErrorCode;
+import umc.stockoneqback.product.dto.response.GetTotalProductResponse;
+import umc.stockoneqback.product.dto.response.SearchProductOthersResponse;
+import umc.stockoneqback.product.exception.ProductErrorCode;
+import umc.stockoneqback.user.exception.UserErrorCode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static umc.stockoneqback.fixture.ProductFixture.*;
+import static umc.stockoneqback.fixture.ProductFixture.PINEAPPLE;
+import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
+import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
+
+@DisplayName("Business [Controller Layer] -> BusinessProductApiController 테스트")
+public class BusinessProductApiControllerTest extends ControllerTest {
+    @Nested
+    @DisplayName("공통 예외")
+    class commonError {
+        private static final String BASE_URL = "/api/business/product/count";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long MANAGER_ID = 2L;
+        private static final String ERROR_STORE_CONDITION = "고온";
+
+        @Test
+        @DisplayName("권한이 없는 사용자가 BusinessProduct API를 호출한 경우 API 호출에 실패한다")
+        void throwExceptionByUnauthorizedUser() throws Exception {
+            // given
+            doThrow(BaseException.type(GlobalErrorCode.INVALID_USER_JWT))
+                    .when(businessProductService)
+                    .getTotalProductOthers(anyLong(), anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("manager", String.valueOf(MANAGER_ID))
+                    .param("condition", STORE_CONDITION)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final GlobalErrorCode expectedError = GlobalErrorCode.INVALID_USER_JWT;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isForbidden(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BusinessProductApi/CommonError/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("manager").description("요청한 사장님 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("입력된 사용자가 요청한 사용자와 비즈니스 관계가 아닌 경우 API 호출에 실패한다")
+        void throwExceptionByConflictFriend() throws Exception {
+            // given
+            doThrow(BaseException.type(BusinessErrorCode.BUSINESS_NOT_FOUND))
+                    .when(businessProductService)
+                    .getTotalProductOthers(anyLong(), anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("manager", String.valueOf(MANAGER_ID))
+                    .param("condition", STORE_CONDITION)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final BusinessErrorCode expectedError = BusinessErrorCode.BUSINESS_NOT_FOUND;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BusinessProductApi/CommonError/Case2",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("manager").description("요청한 사장님 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("입력된 사용자가 유효하지 않은 역할을 가지고 있는 경우 API 호출에 실패한다")
+        void throwExceptionByInvalidUser() throws Exception {
+            // given
+            doThrow(BaseException.type(UserErrorCode.ROLE_NOT_FOUND))
+                    .when(businessProductService)
+                    .getTotalProductOthers(anyLong(), anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("manager", String.valueOf(MANAGER_ID))
+                    .param("condition", STORE_CONDITION)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final UserErrorCode expectedError = UserErrorCode.ROLE_NOT_FOUND;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BusinessProductApi/CommonError/Case3",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("manager").description("요청한 사장님 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("입력된 사장님의 가게를 불러올 수 없는 경우 API 호출에 실패한다")
+        void throwExceptionByConflictFriendAndStore() throws Exception {
+            // given
+            doThrow(BaseException.type(UserErrorCode.USER_STORE_MATCH_FAIL))
+                    .when(businessProductService)
+                    .getTotalProductOthers(anyLong(), anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("manager", String.valueOf(MANAGER_ID))
+                    .param("condition", STORE_CONDITION)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final UserErrorCode expectedError = UserErrorCode.USER_STORE_MATCH_FAIL;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isBadRequest(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BusinessProductApi/CommonError/Case4",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("manager").description("요청한 사장님 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("입력된 보관방법이 잘못된 경우 API 호출에 실패한다")
+        void throwExceptionByInvalidStoreCondition() throws Exception {
+            // given
+            doThrow(BaseException.type(ProductErrorCode.NOT_FOUND_STORE_CONDITION))
+                    .when(businessProductService)
+                    .getTotalProductOthers(anyLong(), anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("manager", String.valueOf(MANAGER_ID))
+                    .param("condition", ERROR_STORE_CONDITION)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final ProductErrorCode expectedError = ProductErrorCode.NOT_FOUND_STORE_CONDITION;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BusinessProductApi/CommonError/Case5",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("manager").description("요청한 사장님 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("사장님 가게의 입력된 이름을 포함하는 모든 제품 목록 조회 API [GET /api/business/product/search]")
+    class getProductOthersByNameIncludeInput {
+        private static final String BASE_URL = "/api/business/product/search";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long MANAGER_ID = 2L;
+        private static final String NAME = "리";
+        private static final String ERROR_NAME = "텐트";
+
+        @Test
+        @DisplayName("입력된 이름을 포함하는 제품이 존재하지 않을 경우 사장님 가게의 입력된 이름을 포함하는 모든 제품 목록 조회에 실패한다")
+        void throwExceptionByInvalidProductName() throws Exception {
+            // given
+            doThrow(BaseException.type(ProductErrorCode.NOT_FOUND_PRODUCT))
+                    .when(businessProductService)
+                    .searchProductOthers(anyLong(), anyLong(), anyString(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("manager", String.valueOf(MANAGER_ID))
+                    .param("condition", STORE_CONDITION)
+                    .param("name", ERROR_NAME)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final ProductErrorCode expectedError = ProductErrorCode.NOT_FOUND_PRODUCT;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BusinessProductApi/GetProductOthersByName/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("manager").description("요청한 사장님 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법"),
+                                            parameterWithName("name").description("검색할 제품명")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("사장님 가게의 입력된 이름을 포함하는 모든 제품 목록 조회에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(searchProductOthersResponse())
+                    .when(businessProductService)
+                    .searchProductOthers(anyLong(), anyLong(), anyString(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("manager", String.valueOf(MANAGER_ID))
+                    .param("condition", STORE_CONDITION)
+                    .param("name", NAME)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result[0]").exists(),
+                            jsonPath("$.result[0].name").value(DURIAN.getName()),
+                            jsonPath("$.result[0].stockQuant").value(DURIAN.getStockQuant()),
+                            jsonPath("$.result[1]").exists(),
+                            jsonPath("$.result[1].name").value(BLUEBERRY.getName()),
+                            jsonPath("$.result[1].stockQuant").value(BLUEBERRY.getStockQuant()),
+                            jsonPath("$.result[2]").exists(),
+                            jsonPath("$.result[2].name").value(CHERRY.getName()),
+                            jsonPath("$.result[2].stockQuant").value(CHERRY.getStockQuant()),
+                            jsonPath("$.result[3]").doesNotExist()
+                    )
+                    .andDo(
+                            document(
+                                    "BusinessProductApi/GetProductOthersByName/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("manager").description("요청한 사장님 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법"),
+                                            parameterWithName("name").description("검색할 제품명")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지"),
+                                            fieldWithPath("result[].id").type(JsonFieldType.NUMBER).description("제품 ID"),
+                                            fieldWithPath("result[].name").type(JsonFieldType.STRING).description("제품명"),
+                                            fieldWithPath("result[].stockQuant").type(JsonFieldType.NUMBER).description("재고 수량"),
+                                            fieldWithPath("result[].image").type(JsonFieldType.ARRAY).description("제품 이미지").optional()
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("사장님 가게의 분류 기준별 제품 개수 조회 API [GET /api/business/product/count]")
+    class getTotalProduct {
+        private static final String BASE_URL = "/api/business/product/count";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long MANAGER_ID = 2L;
+
+        @Test
+        @DisplayName("사장님 가게의 분류 기준별 제품 개수 조회에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(getTotalProductResponse())
+                    .when(businessProductService)
+                    .getTotalProductOthers(anyLong(), anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("manager", String.valueOf(MANAGER_ID))
+                    .param("condition", STORE_CONDITION)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result[0]").exists(),
+                            jsonPath("$.result[0].name").value("Total"),
+                            jsonPath("$.result[0].total").value(16),
+                            jsonPath("$.result[1]").exists(),
+                            jsonPath("$.result[1].name").value("Pass"),
+                            jsonPath("$.result[1].total").value(2),
+                            jsonPath("$.result[2]").exists(),
+                            jsonPath("$.result[2].name").value("Close"),
+                            jsonPath("$.result[2].total").value(5),
+                            jsonPath("$.result[3]").exists(),
+                            jsonPath("$.result[3].name").value("Lack"),
+                            jsonPath("$.result[3].total").value(5),
+                            jsonPath("$.result[4]").doesNotExist()
+                    )
+                    .andDo(
+                            document(
+                                    "BusinessProductApi/GetTotal/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("manager").description("요청한 사장님 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지"),
+                                            fieldWithPath("result[].name").type(JsonFieldType.STRING).description("분류 기준"),
+                                            fieldWithPath("result[].total").type(JsonFieldType.NUMBER).description("제품의 총 개수")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("사장님 가게의 특정 정렬 기준을 만족하는 전체 제품 조회 API [GET /api/business/product/all]")
+    class getAllProductOthers {
+        private static final String BASE_URL = "/api/business/product/all";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long MANAGER_ID = 2L;
+        private static final String CATEGORY = "All";
+        private static final List<ProductFixture> productFixtureList = new ArrayList<>(
+                Stream.of(PERSIMMON, TANGERINE, DURIAN, MANGO, MELON,
+                        BANANA, PEAR, PEACH, BLUEBERRY).collect(Collectors.toList())
+        );
+
+        @Test
+        @DisplayName("사장님 가게의 특정 정렬 기준을 만족하는 전체 제품 조회에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(searchAllProductOthersResponse())
+                    .when(businessProductService)
+                    .getListOfCategoryProductOthers(anyLong(), eq(MANAGER_ID), eq(STORE_CONDITION), isNull(), eq(CATEGORY));
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("manager", String.valueOf(MANAGER_ID))
+                    .param("condition", STORE_CONDITION)
+                    .param("last", (String) null)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result[0]").exists(),
+                            jsonPath("$.result[0].name").value(productFixtureList.get(0).getName()),
+                            jsonPath("$.result[0].stockQuant").value(productFixtureList.get(0).getStockQuant()),
+                            jsonPath("$.result[1]").exists(),
+                            jsonPath("$.result[1].name").value(productFixtureList.get(1).getName()),
+                            jsonPath("$.result[1].stockQuant").value(productFixtureList.get(1).getStockQuant()),
+                            jsonPath("$.result[2]").exists(),
+                            jsonPath("$.result[2].name").value(productFixtureList.get(2).getName()),
+                            jsonPath("$.result[2].stockQuant").value(productFixtureList.get(2).getStockQuant()),
+                            jsonPath("$.result[3]").exists(),
+                            jsonPath("$.result[3].name").value(productFixtureList.get(3).getName()),
+                            jsonPath("$.result[3].stockQuant").value(productFixtureList.get(3).getStockQuant()),
+                            jsonPath("$.result[4]").exists(),
+                            jsonPath("$.result[4].name").value(productFixtureList.get(4).getName()),
+                            jsonPath("$.result[4].stockQuant").value(productFixtureList.get(4).getStockQuant()),
+                            jsonPath("$.result[5]").exists(),
+                            jsonPath("$.result[5].name").value(productFixtureList.get(5).getName()),
+                            jsonPath("$.result[5].stockQuant").value(productFixtureList.get(5).getStockQuant()),
+                            jsonPath("$.result[6]").exists(),
+                            jsonPath("$.result[6].name").value(productFixtureList.get(6).getName()),
+                            jsonPath("$.result[6].stockQuant").value(productFixtureList.get(6).getStockQuant()),
+                            jsonPath("$.result[7]").exists(),
+                            jsonPath("$.result[7].name").value(productFixtureList.get(7).getName()),
+                            jsonPath("$.result[7].stockQuant").value(productFixtureList.get(7).getStockQuant()),
+                            jsonPath("$.result[8]").exists(),
+                            jsonPath("$.result[8].name").value(productFixtureList.get(8).getName()),
+                            jsonPath("$.result[8].stockQuant").value(productFixtureList.get(8).getStockQuant()),
+                            jsonPath("$.result[9]").doesNotExist()
+                    )
+                    .andDo(
+                            document(
+                                    "BusinessProductApi/GetAll/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("manager").description("요청한 사장님 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법"),
+                                            parameterWithName("last").description("마지막 제품 ID(첫 요청 때에는 불필요)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지"),
+                                            fieldWithPath("result[].id").type(JsonFieldType.NUMBER).description("제품 ID"),
+                                            fieldWithPath("result[].name").type(JsonFieldType.STRING).description("제품명"),
+                                            fieldWithPath("result[].stockQuant").type(JsonFieldType.NUMBER).description("재고 수량"),
+                                            fieldWithPath("result[].image").type(JsonFieldType.ARRAY).description("제품 이미지").optional()
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("사장님 가게의 특정 정렬 기준을 만족하는 유통기한 경과 제품 조회 API [GET /api/business/product/pass]")
+    class getPassProductOthers {
+        private static final String BASE_URL = "/api/business/product/pass";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long MANAGER_ID = 2L;
+        private static final String CATEGORY = "Pass";
+        private static final List<ProductFixture> productFixtureList = new ArrayList<>(
+                Stream.of(PERSIMMON, GRAPE).collect(Collectors.toList())
+        );
+
+        @Test
+        @DisplayName("친구 가게의 특정 정렬 기준을 만족하는 유통기한 경과 제품 조회에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(searchPassProductOthersResponse())
+                    .when(businessProductService)
+                    .getListOfCategoryProductOthers(anyLong(), eq(MANAGER_ID), eq(STORE_CONDITION), isNull(), eq(CATEGORY));
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("manager", String.valueOf(MANAGER_ID))
+                    .param("condition", STORE_CONDITION)
+                    .param("last", (String) null)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result[0]").exists(),
+                            jsonPath("$.result[0].name").value(productFixtureList.get(0).getName()),
+                            jsonPath("$.result[0].stockQuant").value(productFixtureList.get(0).getStockQuant()),
+                            jsonPath("$.result[1]").exists(),
+                            jsonPath("$.result[1].name").value(productFixtureList.get(1).getName()),
+                            jsonPath("$.result[1].stockQuant").value(productFixtureList.get(1).getStockQuant()),
+                            jsonPath("$.result[2]").doesNotExist()
+                    )
+                    .andDo(
+                            document(
+                                    "BusinessProductApi/GetPass/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("manager").description("요청한 사장님 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법"),
+                                            parameterWithName("last").description("마지막 제품 ID(첫 요청 때에는 불필요)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지"),
+                                            fieldWithPath("result[].id").type(JsonFieldType.NUMBER).description("제품 ID"),
+                                            fieldWithPath("result[].name").type(JsonFieldType.STRING).description("제품명"),
+                                            fieldWithPath("result[].stockQuant").type(JsonFieldType.NUMBER).description("재고 수량"),
+                                            fieldWithPath("result[].image").type(JsonFieldType.ARRAY).description("제품 이미지").optional()
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("사장님 가게의 특정 정렬 기준을 만족하는 유통기한 임박 제품 조회 API [GET /api/business/product/close]")
+    class getCloseProductOthers {
+        private static final String BASE_URL = "/api/business/product/close";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long MANAGER_ID = 2L;
+        private static final String CATEGORY = "Close";
+        private static final List<ProductFixture> productFixtureList = new ArrayList<>(
+                Stream.of(DURIAN, MELON, APPLE, PLUM, CHERRY).collect(Collectors.toList())
+        );
+
+        @Test
+        @DisplayName("친구 가게의 특정 정렬 기준을 만족하는 유통기한 임박 제품 조회에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(searchCloseProductOthersResponse())
+                    .when(businessProductService)
+                    .getListOfCategoryProductOthers(anyLong(), eq(MANAGER_ID), eq(STORE_CONDITION), isNull(), eq(CATEGORY));
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("manager", String.valueOf(MANAGER_ID))
+                    .param("condition", STORE_CONDITION)
+                    .param("last", (String) null)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result[0]").exists(),
+                            jsonPath("$.result[0].name").value(productFixtureList.get(0).getName()),
+                            jsonPath("$.result[0].stockQuant").value(productFixtureList.get(0).getStockQuant()),
+                            jsonPath("$.result[1]").exists(),
+                            jsonPath("$.result[1].name").value(productFixtureList.get(1).getName()),
+                            jsonPath("$.result[1].stockQuant").value(productFixtureList.get(1).getStockQuant()),
+                            jsonPath("$.result[2]").exists(),
+                            jsonPath("$.result[2].name").value(productFixtureList.get(2).getName()),
+                            jsonPath("$.result[2].stockQuant").value(productFixtureList.get(2).getStockQuant()),
+                            jsonPath("$.result[3]").exists(),
+                            jsonPath("$.result[3].name").value(productFixtureList.get(3).getName()),
+                            jsonPath("$.result[3].stockQuant").value(productFixtureList.get(3).getStockQuant()),
+                            jsonPath("$.result[4]").exists(),
+                            jsonPath("$.result[4].name").value(productFixtureList.get(4).getName()),
+                            jsonPath("$.result[4].stockQuant").value(productFixtureList.get(4).getStockQuant()),
+                            jsonPath("$.result[5]").doesNotExist()
+                    )
+                    .andDo(
+                            document(
+                                    "BusinessProductApi/GetClose/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("manager").description("요청한 사장님 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법"),
+                                            parameterWithName("last").description("마지막 제품 ID(첫 요청 때에는 불필요)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지"),
+                                            fieldWithPath("result[].id").type(JsonFieldType.NUMBER).description("제품 ID"),
+                                            fieldWithPath("result[].name").type(JsonFieldType.STRING).description("제품명"),
+                                            fieldWithPath("result[].stockQuant").type(JsonFieldType.NUMBER).description("재고 수량"),
+                                            fieldWithPath("result[].image").type(JsonFieldType.ARRAY).description("제품 이미지").optional()
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("사장님 가게의 특정 정렬 기준을 만족하는 재고 부족 제품 조회 API [GET /api/business/product/lack]")
+    class getLackProductOthers {
+        private static final String BASE_URL = "/api/business/product/lack";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long MANAGER_ID = 2L;
+        private static final String CATEGORY = "Lack";
+        private static final List<ProductFixture> productFixtureList = new ArrayList<>(
+                Stream.of(PEAR, PEACH, APPLE, CHERRY, PINEAPPLE).collect(Collectors.toList())
+        );
+
+        @Test
+        @DisplayName("사장님 가게의 특정 정렬 기준을 만족하는 재고 부족 제품 조회에 성공한다")
+        void success() throws Exception{
+            // given
+            doReturn(searchLackProductOthersResponse())
+                    .when(businessProductService)
+                    .getListOfCategoryProductOthers(anyLong(), eq(MANAGER_ID), eq(STORE_CONDITION), isNull(), eq(CATEGORY));
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("manager", String.valueOf(MANAGER_ID))
+                    .param("condition", STORE_CONDITION)
+                    .param("last", (String) null)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result[0]").exists(),
+                            jsonPath("$.result[0].name").value(productFixtureList.get(0).getName()),
+                            jsonPath("$.result[0].stockQuant").value(productFixtureList.get(0).getStockQuant()),
+                            jsonPath("$.result[1]").exists(),
+                            jsonPath("$.result[1].name").value(productFixtureList.get(1).getName()),
+                            jsonPath("$.result[1].stockQuant").value(productFixtureList.get(1).getStockQuant()),
+                            jsonPath("$.result[2]").exists(),
+                            jsonPath("$.result[2].name").value(productFixtureList.get(2).getName()),
+                            jsonPath("$.result[2].stockQuant").value(productFixtureList.get(2).getStockQuant()),
+                            jsonPath("$.result[3]").exists(),
+                            jsonPath("$.result[3].name").value(productFixtureList.get(3).getName()),
+                            jsonPath("$.result[3].stockQuant").value(productFixtureList.get(3).getStockQuant()),
+                            jsonPath("$.result[4]").exists(),
+                            jsonPath("$.result[4].name").value(productFixtureList.get(4).getName()),
+                            jsonPath("$.result[4].stockQuant").value(productFixtureList.get(4).getStockQuant()),
+                            jsonPath("$.result[5]").doesNotExist()
+                    )
+                    .andDo(
+                            document(
+                                    "BusinessProductApi/GetLack/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("manager").description("요청한 사장님 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법"),
+                                            parameterWithName("last").description("마지막 제품 ID(첫 요청 때에는 불필요)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지"),
+                                            fieldWithPath("result[].id").type(JsonFieldType.NUMBER).description("제품 ID"),
+                                            fieldWithPath("result[].name").type(JsonFieldType.STRING).description("제품명"),
+                                            fieldWithPath("result[].stockQuant").type(JsonFieldType.NUMBER).description("재고 수량"),
+                                            fieldWithPath("result[].image").type(JsonFieldType.ARRAY).description("제품 이미지").optional()
+                                    )
+                            )
+                    );
+        }
+    }
+
+    private List<SearchProductOthersResponse> searchProductOthersResponse() {
+        List<SearchProductOthersResponse> searchProductOthersResponseList = new ArrayList<>();
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(4L, DURIAN.getName(), DURIAN.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(11L, BLUEBERRY.getName(), BLUEBERRY.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(8L, CHERRY.getName(), CHERRY.getStockQuant(), null));
+        return searchProductOthersResponseList;
+    }
+
+    private List<GetTotalProductResponse> getTotalProductResponse() {
+        List<GetTotalProductResponse> getTotalProductResponseList = new ArrayList<>();
+        getTotalProductResponseList.add(new GetTotalProductResponse("Total", 16));
+        getTotalProductResponseList.add(new GetTotalProductResponse("Pass", 2));
+        getTotalProductResponseList.add(new GetTotalProductResponse("Close", 5));
+        getTotalProductResponseList.add(new GetTotalProductResponse("Lack", 5));
+        return getTotalProductResponseList;
+    }
+
+    private List<SearchProductOthersResponse> searchAllProductOthersResponse() {
+        List<SearchProductOthersResponse> searchProductOthersResponseList = new ArrayList<>();
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(16L, PERSIMMON.getName(), PERSIMMON.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(15L, TANGERINE.getName(), TANGERINE.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(4L, DURIAN.getName(), DURIAN.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(3L, MANGO.getName(), MANGO.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(9L, MELON.getName(), MELON.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(2L, BANANA.getName(), BANANA.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(17L, PEAR.getName(), PEAR.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(13L, PEACH.getName(), PEACH.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(11L, BLUEBERRY.getName(), BLUEBERRY.getStockQuant(), null));
+        return searchProductOthersResponseList;
+    }
+
+    private List<SearchProductOthersResponse> searchPassProductOthersResponse() {
+        List<SearchProductOthersResponse> searchProductOthersResponseList = new ArrayList<>();
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(16L, PERSIMMON.getName(), PERSIMMON.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(7L, GRAPE.getName(), GRAPE.getStockQuant(), null));
+        return searchProductOthersResponseList;
+    }
+
+    private List<SearchProductOthersResponse> searchCloseProductOthersResponse() {
+        List<SearchProductOthersResponse> searchProductOthersResponseList = new ArrayList<>();
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(4L, DURIAN.getName(), DURIAN.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(9L, MELON.getName(), MELON.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(1L, APPLE.getName(), APPLE.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(14L, PLUM.getName(), PLUM.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(8L, CHERRY.getName(), CHERRY.getStockQuant(), null));
+        return searchProductOthersResponseList;
+    }
+
+    private List<SearchProductOthersResponse> searchLackProductOthersResponse() {
+        List<SearchProductOthersResponse> searchProductOthersResponseList = new ArrayList<>();
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(17L, PEAR.getName(), PEAR.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(13L, PEACH.getName(), PEACH.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(1L, APPLE.getName(), APPLE.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(8L, CHERRY.getName(), CHERRY.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(6L, PINEAPPLE.getName(), PINEAPPLE.getStockQuant(), null));
+        return searchProductOthersResponseList;
+    }
+}

--- a/src/test/java/umc/stockoneqback/common/ControllerTest.java
+++ b/src/test/java/umc/stockoneqback/common/ControllerTest.java
@@ -25,6 +25,8 @@ import umc.stockoneqback.board.service.BoardFindService;
 import umc.stockoneqback.board.service.BoardService;
 import umc.stockoneqback.board.service.like.BoardLikeService;
 import umc.stockoneqback.business.controller.BusinessApiController;
+import umc.stockoneqback.business.controller.BusinessProductApiController;
+import umc.stockoneqback.business.service.BusinessProductService;
 import umc.stockoneqback.business.service.BusinessService;
 import umc.stockoneqback.comment.controller.CommentApiController;
 import umc.stockoneqback.comment.service.CommentFindService;
@@ -32,13 +34,16 @@ import umc.stockoneqback.comment.service.CommentService;
 import umc.stockoneqback.friend.controller.FriendApiController;
 import umc.stockoneqback.friend.controller.FriendFindApiController;
 import umc.stockoneqback.friend.controller.FriendInformationController;
+import umc.stockoneqback.friend.controller.FriendProductApiController;
 import umc.stockoneqback.friend.service.FriendFindService;
 import umc.stockoneqback.friend.service.FriendInformationService;
+import umc.stockoneqback.friend.service.FriendProductService;
 import umc.stockoneqback.friend.service.FriendService;
 import umc.stockoneqback.global.security.handler.JwtAccessDeniedHandler;
 import umc.stockoneqback.global.security.handler.JwtAuthenticationEntryPoint;
 import umc.stockoneqback.global.security.service.CustomUserDetailsService;
 import umc.stockoneqback.product.controller.ProductApiController;
+import umc.stockoneqback.product.service.ProductOthersService;
 import umc.stockoneqback.product.service.ProductService;
 import umc.stockoneqback.reply.controller.ReplyApiController;
 import umc.stockoneqback.reply.service.ReplyFindService;
@@ -65,7 +70,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         FriendFindApiController.class,
         BoardLikeApiController.class,
         FriendInformationController.class,
-        TokenReissueApiController.class
+        TokenReissueApiController.class,
+        FriendProductApiController.class,
+        BusinessProductApiController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 @AutoConfigureRestDocs
@@ -141,6 +148,15 @@ public abstract class ControllerTest {
 
     @MockBean
     protected TokenReissueService tokenReissueService;
+
+    @MockBean
+    protected FriendProductService friendProductService;
+
+    @MockBean
+    protected BusinessProductService businessProductService;
+
+    @MockBean
+    protected ProductOthersService productOthersService;
 
     @BeforeEach
     void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {

--- a/src/test/java/umc/stockoneqback/friend/controller/FriendProductApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/friend/controller/FriendProductApiControllerTest.java
@@ -1,0 +1,838 @@
+package umc.stockoneqback.friend.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import umc.stockoneqback.common.ControllerTest;
+import umc.stockoneqback.fixture.ProductFixture;
+import umc.stockoneqback.friend.exception.FriendErrorCode;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.global.base.GlobalErrorCode;
+import umc.stockoneqback.product.dto.response.GetTotalProductResponse;
+import umc.stockoneqback.product.dto.response.SearchProductOthersResponse;
+import umc.stockoneqback.product.exception.ProductErrorCode;
+import umc.stockoneqback.user.exception.UserErrorCode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static umc.stockoneqback.fixture.ProductFixture.*;
+import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
+import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
+
+@DisplayName("Friend [Controller Layer] -> FriendProductApiController 테스트")
+public class FriendProductApiControllerTest extends ControllerTest {
+    @Nested
+    @DisplayName("공통 예외")
+    class commonError {
+        private static final String BASE_URL = "/api/friend/product/count";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long FRIEND_ID = 2L;
+        private static final String ERROR_STORE_CONDITION = "고온";
+
+        @Test
+        @DisplayName("권한이 없는 사용자가 FriendProduct API를 호출한 경우 API 호출에 실패한다")
+        void throwExceptionByUnauthorizedUser() throws Exception {
+            // given
+            doThrow(BaseException.type(GlobalErrorCode.INVALID_USER_JWT))
+                    .when(friendProductService)
+                    .getTotalProductOthers(anyLong(), anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("friend", String.valueOf(FRIEND_ID))
+                    .param("condition", STORE_CONDITION)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final GlobalErrorCode expectedError = GlobalErrorCode.INVALID_USER_JWT;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isForbidden(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "FriendProductApi/CommonError/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("friend").description("요청한 친구 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("입력된 사용자가 요청한 사용자와 친구가 아닌 경우 API 호출에 실패한다")
+        void throwExceptionByConflictFriend() throws Exception {
+            // given
+            doThrow(BaseException.type(FriendErrorCode.FRIEND_NOT_FOUND))
+                    .when(friendProductService)
+                    .getTotalProductOthers(anyLong(), anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("friend", String.valueOf(FRIEND_ID))
+                    .param("condition", STORE_CONDITION)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final FriendErrorCode expectedError = FriendErrorCode.FRIEND_NOT_FOUND;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "FriendProductApi/CommonError/Case2",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("friend").description("요청한 친구 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("입력된 사용자가 유효하지 않은 역할을 가지고 있는 경우 API 호출에 실패한다")
+        void throwExceptionByInvalidUser() throws Exception {
+            // given
+            doThrow(BaseException.type(UserErrorCode.ROLE_NOT_FOUND))
+                    .when(friendProductService)
+                    .getTotalProductOthers(anyLong(), anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("friend", String.valueOf(FRIEND_ID))
+                    .param("condition", STORE_CONDITION)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final UserErrorCode expectedError = UserErrorCode.ROLE_NOT_FOUND;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "FriendProductApi/CommonError/Case3",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("friend").description("요청한 친구 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("입력된 친구의 가게를 불러올 수 없는 경우 API 호출에 실패한다")
+        void throwExceptionByConflictFriendAndStore() throws Exception {
+            // given
+            doThrow(BaseException.type(UserErrorCode.USER_STORE_MATCH_FAIL))
+                    .when(friendProductService)
+                    .getTotalProductOthers(anyLong(), anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("friend", String.valueOf(FRIEND_ID))
+                    .param("condition", STORE_CONDITION)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final UserErrorCode expectedError = UserErrorCode.USER_STORE_MATCH_FAIL;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isBadRequest(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "FriendProductApi/CommonError/Case4",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("friend").description("요청한 친구 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("입력된 보관방법이 잘못된 경우 API 호출에 실패한다")
+        void throwExceptionByInvalidStoreCondition() throws Exception {
+            // given
+            doThrow(BaseException.type(ProductErrorCode.NOT_FOUND_STORE_CONDITION))
+                    .when(friendProductService)
+                    .getTotalProductOthers(anyLong(), anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("friend", String.valueOf(FRIEND_ID))
+                    .param("condition", ERROR_STORE_CONDITION)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final ProductErrorCode expectedError = ProductErrorCode.NOT_FOUND_STORE_CONDITION;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "FriendProductApi/CommonError/Case5",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("friend").description("요청한 친구 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("친구 가게의 입력된 이름을 포함하는 모든 제품 목록 조회 API [GET /api/friend/product/search]")
+    class getProductOthersByNameIncludeInput {
+        private static final String BASE_URL = "/api/friend/product/search";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long FRIEND_ID = 2L;
+        private static final String NAME = "리";
+        private static final String ERROR_NAME = "텐트";
+
+        @Test
+        @DisplayName("입력된 이름을 포함하는 제품이 존재하지 않을 경우 친구 가게의 입력된 이름을 포함하는 모든 제품 목록 조회에 실패한다")
+        void throwExceptionByInvalidProductName() throws Exception {
+            // given
+            doThrow(BaseException.type(ProductErrorCode.NOT_FOUND_PRODUCT))
+                    .when(friendProductService)
+                    .searchProductOthers(anyLong(), anyLong(), anyString(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("friend", String.valueOf(FRIEND_ID))
+                    .param("condition", STORE_CONDITION)
+                    .param("name", ERROR_NAME)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final ProductErrorCode expectedError = ProductErrorCode.NOT_FOUND_PRODUCT;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "FriendProductApi/GetProductOthersByName/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("friend").description("요청한 친구 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법"),
+                                            parameterWithName("name").description("검색할 제품명")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("친구 가게의 입력된 이름을 포함하는 모든 제품 목록 조회에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(searchProductOthersResponse())
+                    .when(friendProductService)
+                    .searchProductOthers(anyLong(), anyLong(), anyString(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("friend", String.valueOf(FRIEND_ID))
+                    .param("condition", STORE_CONDITION)
+                    .param("name", NAME)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result[0]").exists(),
+                            jsonPath("$.result[0].name").value(DURIAN.getName()),
+                            jsonPath("$.result[0].stockQuant").value(DURIAN.getStockQuant()),
+                            jsonPath("$.result[1]").exists(),
+                            jsonPath("$.result[1].name").value(BLUEBERRY.getName()),
+                            jsonPath("$.result[1].stockQuant").value(BLUEBERRY.getStockQuant()),
+                            jsonPath("$.result[2]").exists(),
+                            jsonPath("$.result[2].name").value(CHERRY.getName()),
+                            jsonPath("$.result[2].stockQuant").value(CHERRY.getStockQuant()),
+                            jsonPath("$.result[3]").doesNotExist()
+                    )
+                    .andDo(
+                            document(
+                                    "FriendProductApi/GetProductOthersByName/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("friend").description("요청한 친구 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법"),
+                                            parameterWithName("name").description("검색할 제품명")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지"),
+                                            fieldWithPath("result[].id").type(JsonFieldType.NUMBER).description("제품 ID"),
+                                            fieldWithPath("result[].name").type(JsonFieldType.STRING).description("제품명"),
+                                            fieldWithPath("result[].stockQuant").type(JsonFieldType.NUMBER).description("재고 수량"),
+                                            fieldWithPath("result[].image").type(JsonFieldType.ARRAY).description("제품 이미지").optional()
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("친구 가게의 분류 기준별 제품 개수 조회 API [GET /api/friend/product/count]")
+    class getTotalProduct {
+        private static final String BASE_URL = "/api/friend/product/count";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long FRIEND_ID = 2L;
+
+        @Test
+        @DisplayName("친구 가게의 분류 기준별 제품 개수 조회에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(getTotalProductResponse())
+                    .when(friendProductService)
+                    .getTotalProductOthers(anyLong(), anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("friend", String.valueOf(FRIEND_ID))
+                    .param("condition", STORE_CONDITION)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result[0]").exists(),
+                            jsonPath("$.result[0].name").value("Total"),
+                            jsonPath("$.result[0].total").value(16),
+                            jsonPath("$.result[1]").exists(),
+                            jsonPath("$.result[1].name").value("Pass"),
+                            jsonPath("$.result[1].total").value(2),
+                            jsonPath("$.result[2]").exists(),
+                            jsonPath("$.result[2].name").value("Close"),
+                            jsonPath("$.result[2].total").value(5),
+                            jsonPath("$.result[3]").exists(),
+                            jsonPath("$.result[3].name").value("Lack"),
+                            jsonPath("$.result[3].total").value(5),
+                            jsonPath("$.result[4]").doesNotExist()
+                    )
+                    .andDo(
+                            document(
+                                    "FriendProductApi/GetTotal/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("friend").description("요청한 친구 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지"),
+                                            fieldWithPath("result[].name").type(JsonFieldType.STRING).description("분류 기준"),
+                                            fieldWithPath("result[].total").type(JsonFieldType.NUMBER).description("제품의 총 개수")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("친구 가게의 특정 정렬 기준을 만족하는 전체 제품 조회 API [GET /api/friend/product/all]")
+    class getAllProductOthers {
+        private static final String BASE_URL = "/api/friend/product/all";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long FRIEND_ID = 2L;
+        private static final String CATEGORY = "All";
+        private static final List<ProductFixture> productFixtureList = new ArrayList<>(
+                Stream.of(PERSIMMON, TANGERINE, DURIAN, MANGO, MELON,
+                        BANANA, PEAR, PEACH, BLUEBERRY).collect(Collectors.toList())
+        );
+
+        @Test
+        @DisplayName("친구 가게의 특정 정렬 기준을 만족하는 전체 제품 조회에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(searchAllProductOthersResponse())
+                    .when(friendProductService)
+                    .getListOfCategoryProductOthers(anyLong(), eq(FRIEND_ID), eq(STORE_CONDITION), isNull(), eq(CATEGORY));
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("friend", String.valueOf(FRIEND_ID))
+                    .param("condition", STORE_CONDITION)
+                    .param("last", (String) null)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result[0]").exists(),
+                            jsonPath("$.result[0].name").value(productFixtureList.get(0).getName()),
+                            jsonPath("$.result[0].stockQuant").value(productFixtureList.get(0).getStockQuant()),
+                            jsonPath("$.result[1]").exists(),
+                            jsonPath("$.result[1].name").value(productFixtureList.get(1).getName()),
+                            jsonPath("$.result[1].stockQuant").value(productFixtureList.get(1).getStockQuant()),
+                            jsonPath("$.result[2]").exists(),
+                            jsonPath("$.result[2].name").value(productFixtureList.get(2).getName()),
+                            jsonPath("$.result[2].stockQuant").value(productFixtureList.get(2).getStockQuant()),
+                            jsonPath("$.result[3]").exists(),
+                            jsonPath("$.result[3].name").value(productFixtureList.get(3).getName()),
+                            jsonPath("$.result[3].stockQuant").value(productFixtureList.get(3).getStockQuant()),
+                            jsonPath("$.result[4]").exists(),
+                            jsonPath("$.result[4].name").value(productFixtureList.get(4).getName()),
+                            jsonPath("$.result[4].stockQuant").value(productFixtureList.get(4).getStockQuant()),
+                            jsonPath("$.result[5]").exists(),
+                            jsonPath("$.result[5].name").value(productFixtureList.get(5).getName()),
+                            jsonPath("$.result[5].stockQuant").value(productFixtureList.get(5).getStockQuant()),
+                            jsonPath("$.result[6]").exists(),
+                            jsonPath("$.result[6].name").value(productFixtureList.get(6).getName()),
+                            jsonPath("$.result[6].stockQuant").value(productFixtureList.get(6).getStockQuant()),
+                            jsonPath("$.result[7]").exists(),
+                            jsonPath("$.result[7].name").value(productFixtureList.get(7).getName()),
+                            jsonPath("$.result[7].stockQuant").value(productFixtureList.get(7).getStockQuant()),
+                            jsonPath("$.result[8]").exists(),
+                            jsonPath("$.result[8].name").value(productFixtureList.get(8).getName()),
+                            jsonPath("$.result[8].stockQuant").value(productFixtureList.get(8).getStockQuant()),
+                            jsonPath("$.result[9]").doesNotExist()
+                    )
+                    .andDo(
+                            document(
+                                    "FriendProductApi/GetAll/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("friend").description("요청한 친구 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법"),
+                                            parameterWithName("last").description("마지막 제품 ID(첫 요청 때에는 불필요)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지"),
+                                            fieldWithPath("result[].id").type(JsonFieldType.NUMBER).description("제품 ID"),
+                                            fieldWithPath("result[].name").type(JsonFieldType.STRING).description("제품명"),
+                                            fieldWithPath("result[].stockQuant").type(JsonFieldType.NUMBER).description("재고 수량"),
+                                            fieldWithPath("result[].image").type(JsonFieldType.ARRAY).description("제품 이미지").optional()
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("친구 가게의 특정 정렬 기준을 만족하는 유통기한 경과 제품 조회 API [GET /api/friend/product/pass]")
+    class getPassProductOthers {
+        private static final String BASE_URL = "/api/friend/product/pass";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long FRIEND_ID = 2L;
+        private static final String CATEGORY = "Pass";
+        private static final List<ProductFixture> productFixtureList = new ArrayList<>(
+                Stream.of(PERSIMMON, GRAPE).collect(Collectors.toList())
+        );
+
+        @Test
+        @DisplayName("친구 가게의 특정 정렬 기준을 만족하는 유통기한 경과 제품 조회에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(searchPassProductOthersResponse())
+                    .when(friendProductService)
+                    .getListOfCategoryProductOthers(anyLong(), eq(FRIEND_ID), eq(STORE_CONDITION), isNull(), eq(CATEGORY));
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("friend", String.valueOf(FRIEND_ID))
+                    .param("condition", STORE_CONDITION)
+                    .param("last", (String) null)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result[0]").exists(),
+                            jsonPath("$.result[0].name").value(productFixtureList.get(0).getName()),
+                            jsonPath("$.result[0].stockQuant").value(productFixtureList.get(0).getStockQuant()),
+                            jsonPath("$.result[1]").exists(),
+                            jsonPath("$.result[1].name").value(productFixtureList.get(1).getName()),
+                            jsonPath("$.result[1].stockQuant").value(productFixtureList.get(1).getStockQuant()),
+                            jsonPath("$.result[2]").doesNotExist()
+                    )
+                    .andDo(
+                            document(
+                                    "FriendProductApi/GetPass/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("friend").description("요청한 친구 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법"),
+                                            parameterWithName("last").description("마지막 제품 ID(첫 요청 때에는 불필요)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지"),
+                                            fieldWithPath("result[].id").type(JsonFieldType.NUMBER).description("제품 ID"),
+                                            fieldWithPath("result[].name").type(JsonFieldType.STRING).description("제품명"),
+                                            fieldWithPath("result[].stockQuant").type(JsonFieldType.NUMBER).description("재고 수량"),
+                                            fieldWithPath("result[].image").type(JsonFieldType.ARRAY).description("제품 이미지").optional()
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("친구 가게의 특정 정렬 기준을 만족하는 유통기한 임박 제품 조회 API [GET /api/friend/product/close]")
+    class getCloseProductOthers {
+        private static final String BASE_URL = "/api/friend/product/close";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long FRIEND_ID = 2L;
+        private static final String CATEGORY = "Close";
+        private static final List<ProductFixture> productFixtureList = new ArrayList<>(
+                Stream.of(DURIAN, MELON, APPLE, PLUM, CHERRY).collect(Collectors.toList())
+        );
+
+        @Test
+        @DisplayName("친구 가게의 특정 정렬 기준을 만족하는 유통기한 임박 제품 조회에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(searchCloseProductOthersResponse())
+                    .when(friendProductService)
+                    .getListOfCategoryProductOthers(anyLong(), eq(FRIEND_ID), eq(STORE_CONDITION), isNull(), eq(CATEGORY));
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("friend", String.valueOf(FRIEND_ID))
+                    .param("condition", STORE_CONDITION)
+                    .param("last", (String) null)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result[0]").exists(),
+                            jsonPath("$.result[0].name").value(productFixtureList.get(0).getName()),
+                            jsonPath("$.result[0].stockQuant").value(productFixtureList.get(0).getStockQuant()),
+                            jsonPath("$.result[1]").exists(),
+                            jsonPath("$.result[1].name").value(productFixtureList.get(1).getName()),
+                            jsonPath("$.result[1].stockQuant").value(productFixtureList.get(1).getStockQuant()),
+                            jsonPath("$.result[2]").exists(),
+                            jsonPath("$.result[2].name").value(productFixtureList.get(2).getName()),
+                            jsonPath("$.result[2].stockQuant").value(productFixtureList.get(2).getStockQuant()),
+                            jsonPath("$.result[3]").exists(),
+                            jsonPath("$.result[3].name").value(productFixtureList.get(3).getName()),
+                            jsonPath("$.result[3].stockQuant").value(productFixtureList.get(3).getStockQuant()),
+                            jsonPath("$.result[4]").exists(),
+                            jsonPath("$.result[4].name").value(productFixtureList.get(4).getName()),
+                            jsonPath("$.result[4].stockQuant").value(productFixtureList.get(4).getStockQuant()),
+                            jsonPath("$.result[5]").doesNotExist()
+                    )
+                    .andDo(
+                            document(
+                                    "FriendProductApi/GetClose/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("friend").description("요청한 친구 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법"),
+                                            parameterWithName("last").description("마지막 제품 ID(첫 요청 때에는 불필요)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지"),
+                                            fieldWithPath("result[].id").type(JsonFieldType.NUMBER).description("제품 ID"),
+                                            fieldWithPath("result[].name").type(JsonFieldType.STRING).description("제품명"),
+                                            fieldWithPath("result[].stockQuant").type(JsonFieldType.NUMBER).description("재고 수량"),
+                                            fieldWithPath("result[].image").type(JsonFieldType.ARRAY).description("제품 이미지").optional()
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("친구 가게의 특정 정렬 기준을 만족하는 재고 부족 제품 조회 API [GET /api/friend/product/lack]")
+    class getLackProductOthers {
+        private static final String BASE_URL = "/api/friend/product/lack";
+        private static final String STORE_CONDITION = "상온";
+        private static final Long FRIEND_ID = 2L;
+        private static final String CATEGORY = "Lack";
+        private static final List<ProductFixture> productFixtureList = new ArrayList<>(
+                Stream.of(PEAR, PEACH, APPLE, CHERRY, PINEAPPLE).collect(Collectors.toList())
+        );
+
+        @Test
+        @DisplayName("친구 가게의 특정 정렬 기준을 만족하는 재고 부족 제품 조회에 성공한다")
+        void success() throws Exception{
+            // given
+            doReturn(searchLackProductOthersResponse())
+                    .when(friendProductService)
+                    .getListOfCategoryProductOthers(anyLong(), eq(FRIEND_ID), eq(STORE_CONDITION), isNull(), eq(CATEGORY));
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("friend", String.valueOf(FRIEND_ID))
+                    .param("condition", STORE_CONDITION)
+                    .param("last", (String) null)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result[0]").exists(),
+                            jsonPath("$.result[0].name").value(productFixtureList.get(0).getName()),
+                            jsonPath("$.result[0].stockQuant").value(productFixtureList.get(0).getStockQuant()),
+                            jsonPath("$.result[1]").exists(),
+                            jsonPath("$.result[1].name").value(productFixtureList.get(1).getName()),
+                            jsonPath("$.result[1].stockQuant").value(productFixtureList.get(1).getStockQuant()),
+                            jsonPath("$.result[2]").exists(),
+                            jsonPath("$.result[2].name").value(productFixtureList.get(2).getName()),
+                            jsonPath("$.result[2].stockQuant").value(productFixtureList.get(2).getStockQuant()),
+                            jsonPath("$.result[3]").exists(),
+                            jsonPath("$.result[3].name").value(productFixtureList.get(3).getName()),
+                            jsonPath("$.result[3].stockQuant").value(productFixtureList.get(3).getStockQuant()),
+                            jsonPath("$.result[4]").exists(),
+                            jsonPath("$.result[4].name").value(productFixtureList.get(4).getName()),
+                            jsonPath("$.result[4].stockQuant").value(productFixtureList.get(4).getStockQuant()),
+                            jsonPath("$.result[5]").doesNotExist()
+                    )
+                    .andDo(
+                            document(
+                                    "FriendProductApi/GetLack/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    requestParameters(
+                                            parameterWithName("friend").description("요청한 친구 ID"),
+                                            parameterWithName("condition").description("현재 설정된 보관방법"),
+                                            parameterWithName("last").description("마지막 제품 ID(첫 요청 때에는 불필요)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지"),
+                                            fieldWithPath("result[].id").type(JsonFieldType.NUMBER).description("제품 ID"),
+                                            fieldWithPath("result[].name").type(JsonFieldType.STRING).description("제품명"),
+                                            fieldWithPath("result[].stockQuant").type(JsonFieldType.NUMBER).description("재고 수량"),
+                                            fieldWithPath("result[].image").type(JsonFieldType.ARRAY).description("제품 이미지").optional()
+                                    )
+                            )
+                    );
+        }
+    }
+
+    private List<SearchProductOthersResponse> searchProductOthersResponse() {
+        List<SearchProductOthersResponse> searchProductOthersResponseList = new ArrayList<>();
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(4L, DURIAN.getName(), DURIAN.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(11L, BLUEBERRY.getName(), BLUEBERRY.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(8L, CHERRY.getName(), CHERRY.getStockQuant(), null));
+        return searchProductOthersResponseList;
+    }
+
+    private List<GetTotalProductResponse> getTotalProductResponse() {
+        List<GetTotalProductResponse> getTotalProductResponseList = new ArrayList<>();
+        getTotalProductResponseList.add(new GetTotalProductResponse("Total", 16));
+        getTotalProductResponseList.add(new GetTotalProductResponse("Pass", 2));
+        getTotalProductResponseList.add(new GetTotalProductResponse("Close", 5));
+        getTotalProductResponseList.add(new GetTotalProductResponse("Lack", 5));
+        return getTotalProductResponseList;
+    }
+
+    private List<SearchProductOthersResponse> searchAllProductOthersResponse() {
+        List<SearchProductOthersResponse> searchProductOthersResponseList = new ArrayList<>();
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(16L, PERSIMMON.getName(), PERSIMMON.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(15L, TANGERINE.getName(), TANGERINE.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(4L, DURIAN.getName(), DURIAN.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(3L, MANGO.getName(), MANGO.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(9L, MELON.getName(), MELON.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(2L, BANANA.getName(), BANANA.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(17L, PEAR.getName(), PEAR.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(13L, PEACH.getName(), PEACH.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(11L, BLUEBERRY.getName(), BLUEBERRY.getStockQuant(), null));
+        return searchProductOthersResponseList;
+    }
+
+    private List<SearchProductOthersResponse> searchPassProductOthersResponse() {
+        List<SearchProductOthersResponse> searchProductOthersResponseList = new ArrayList<>();
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(16L, PERSIMMON.getName(), PERSIMMON.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(7L, GRAPE.getName(), GRAPE.getStockQuant(), null));
+        return searchProductOthersResponseList;
+    }
+
+    private List<SearchProductOthersResponse> searchCloseProductOthersResponse() {
+        List<SearchProductOthersResponse> searchProductOthersResponseList = new ArrayList<>();
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(4L, DURIAN.getName(), DURIAN.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(9L, MELON.getName(), MELON.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(1L, APPLE.getName(), APPLE.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(14L, PLUM.getName(), PLUM.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(8L, CHERRY.getName(), CHERRY.getStockQuant(), null));
+        return searchProductOthersResponseList;
+    }
+
+    private List<SearchProductOthersResponse> searchLackProductOthersResponse() {
+        List<SearchProductOthersResponse> searchProductOthersResponseList = new ArrayList<>();
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(17L, PEAR.getName(), PEAR.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(13L, PEACH.getName(), PEACH.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(1L, APPLE.getName(), APPLE.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(8L, CHERRY.getName(), CHERRY.getStockQuant(), null));
+        searchProductOthersResponseList.add(new SearchProductOthersResponse(6L, PINEAPPLE.getName(), PINEAPPLE.getStockQuant(), null));
+        return searchProductOthersResponseList;
+    }
+
+}


### PR DESCRIPTION
## Summary 📌
- 유저 재고 목록 API를 구현한다
## Describe your changes 📝
- 사장님이 연결된 친구 사장님 재고 조회
- 슈퍼바이저가 연결된 사장님 재고 조회
## Check list ✅
- [X] I write PR according to the form
- [X] All tests are passed
- [X] Program works normally
- [X] I set proper PR labels
- [X] I remove any redundant codes

## Opinions 🗣️
- 친구와 사장님 재고 조회는 각각의 페이지에서 URI를 받도록 하는 것이 좋을 것 같아 분리 구현하였고 각각의 서비스 단에서는 유저 및 유저 간 관계 검증 로직을 거친 뒤 Product 내부의 ProductOthersService 쪽에서 제품 관련 공통 로직이 동작하도록 설계했습니다.
- API 명세서는 작성하여 노션에 올려두었습니다.
- 각각의 서비스 단에 대한 테스트 코드만 작성이 안된 상태입니다. 이후 이슈 생성하여 작성하도록 하겠습니다😅
## Issue numbers and link 🚪
Closes #81 