### PR TITLE
[Feat] 커뮤니티 게시글 세부 조회 API를 구현한다

### DIFF
--- a/src/docs/asciidoc/board.adoc
+++ b/src/docs/asciidoc/board.adoc
@@ -156,3 +156,27 @@ include::{snippets}/BoardApi/Like/Register/Failure/Case3/path-parameters.adoc[]
 
 HTTP Response
 include::{snippets}/BoardApi/Like/Cancel/Success/http-response.adoc[]
+
+= Board 상세조회 API
+
+== 게시글 상세조회
+=== 1. 유효하지 않은 권한으로 게시글 상세 조회 시 실패한다
+HTTP Request
+include::{snippets}/BoardApi/Detail/Failure/Case1/http-request.adoc[]
+include::{snippets}/BoardApi/Detail/Failure/Case1/request-headers.adoc[]
+include::{snippets}/BoardApi/Detail/Failure/Case1/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Detail/Failure/Case1/http-response.adoc[]
+include::{snippets}/BoardApi/Detail/Failure/Case1/response-fields.adoc[]
+
+==== 2. 게시글 상세조회에 성공한다
+HTTP Request
+include::{snippets}/BoardApi/Detail/Success/http-request.adoc[]
+include::{snippets}/BoardApi/Detail/Success/request-headers.adoc[]
+include::{snippets}/BoardApi/Detail/Failure/Case1/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/BoardApi/Detail/Success/http-response.adoc[]
+include::{snippets}/BoardApi/Detail/Success/response-fields.adoc[]
+

--- a/src/main/java/umc/stockoneqback/board/controller/BoardApiController.java
+++ b/src/main/java/umc/stockoneqback/board/controller/BoardApiController.java
@@ -5,10 +5,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import umc.stockoneqback.board.controller.dto.BoardRequest;
+import umc.stockoneqback.board.controller.dto.BoardResponse;
 import umc.stockoneqback.board.service.BoardService;
 import umc.stockoneqback.global.annotation.ExtractPayload;
 
 import javax.validation.Valid;
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,5 +39,11 @@ public class BoardApiController {
     public ResponseEntity<Void> delete(@ExtractPayload Long writerId, @PathVariable Long boardId) {
         boardService.delete(writerId, boardId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{boardId}")
+    public ResponseEntity<BoardResponse> loadBoard(@ExtractPayload Long userId,
+                                                   @PathVariable Long boardId) throws IOException {
+        return ResponseEntity.ok(boardService.loadBoard(userId, boardId));
     }
 }

--- a/src/main/java/umc/stockoneqback/board/controller/dto/BoardRequest.java
+++ b/src/main/java/umc/stockoneqback/board/controller/dto/BoardRequest.java
@@ -9,8 +9,6 @@ public record BoardRequest(
         @Size(max = 37, message = "제목은 37자 이내로 작성해주세요.")
         String title,
 
-        String file,
-
         @NotBlank(message = "내용 작성은 필수입니다.")
         @Size(min = 1, message = "내용은 최소 1자 이상으로 작성해주세요.")
         @Size(max = 5000, message = "내용은 5000자 이내로 작성해주세요.")

--- a/src/main/java/umc/stockoneqback/board/controller/dto/BoardResponse.java
+++ b/src/main/java/umc/stockoneqback/board/controller/dto/BoardResponse.java
@@ -1,0 +1,15 @@
+package umc.stockoneqback.board.controller.dto;
+
+import lombok.Builder;
+
+@Builder
+public record BoardResponse(
+        Long id,
+
+        String title,
+
+        byte[] file,
+
+        String content
+) {
+}

--- a/src/main/java/umc/stockoneqback/board/service/BoardService.java
+++ b/src/main/java/umc/stockoneqback/board/service/BoardService.java
@@ -4,13 +4,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import umc.stockoneqback.board.controller.dto.BoardResponse;
 import umc.stockoneqback.board.domain.Board;
 import umc.stockoneqback.board.domain.BoardRepository;
 import umc.stockoneqback.board.exception.BoardErrorCode;
 import umc.stockoneqback.file.service.FileService;
 import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.global.base.GlobalErrorCode;
+import umc.stockoneqback.user.domain.Role;
 import umc.stockoneqback.user.domain.User;
 import umc.stockoneqback.user.service.UserFindService;
+
+import java.io.IOException;
 
 @Service
 @Transactional(readOnly = true)
@@ -52,10 +57,41 @@ public class BoardService {
         boardRepository.deleteById(boardId);
     }
 
+    @Transactional
+    public BoardResponse loadBoard(Long userId, Long boardId) throws IOException{
+        Board board = boardFindService.findById(boardId);
+        validateUser(userId);
+        byte[] file = getImageOrElseNull(board.getFile());
+        return BoardResponse.builder()
+                .id(board.getId())
+                .title(board.getTitle())
+                .file(file)
+                .content(board.getContent())
+                .build();
+    }
+
     private void validateWriter(Long boardId, Long writerId) {
         Board board = boardFindService.findById(boardId);
         if (!board.getWriter().getId().equals(writerId)) {
             throw BaseException.type(BoardErrorCode.USER_IS_NOT_BOARD_WRITER);
         }
+    }
+
+    private void validateUser(Long userId) {
+        User user = userFindService.findById(userId);
+        if (user.getRole() == Role.SUPERVISOR)
+            throw BaseException.type(GlobalErrorCode.INVALID_USER_JWT);
+        else if (user.getRole() == Role.PART_TIMER) {
+            throw BaseException.type(GlobalErrorCode.INVALID_USER_JWT);
+        }
+        else if (user.getRole() == Role.MANAGER) {
+            return;
+        }
+    }
+
+    private byte[] getImageOrElseNull(String file) throws IOException {
+        if (file == null)
+            return null;
+        return fileService.downloadToResponseDto(file);
     }
 }

--- a/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
@@ -16,8 +16,6 @@ import umc.stockoneqback.board.exception.BoardErrorCode;
 import umc.stockoneqback.common.ControllerTest;
 import umc.stockoneqback.global.base.BaseException;
 import umc.stockoneqback.global.base.GlobalErrorCode;
-import umc.stockoneqback.product.exception.ProductErrorCode;
-import umc.stockoneqback.user.exception.UserErrorCode;
 
 import java.nio.charset.StandardCharsets;
 
@@ -36,9 +34,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static umc.stockoneqback.common.DocumentFormatGenerator.*;
-import static umc.stockoneqback.common.DocumentFormatGenerator.getDateFormat;
 import static umc.stockoneqback.fixture.BoardFixture.BOARD_0;
-import static umc.stockoneqback.fixture.ProductFixture.APPLE;
 import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
 import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
 

--- a/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
@@ -6,18 +6,24 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import umc.stockoneqback.auth.exception.AuthErrorCode;
 import umc.stockoneqback.board.controller.dto.BoardRequest;
+import umc.stockoneqback.board.controller.dto.BoardResponse;
 import umc.stockoneqback.board.exception.BoardErrorCode;
 import umc.stockoneqback.common.ControllerTest;
 import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.global.base.GlobalErrorCode;
+import umc.stockoneqback.product.exception.ProductErrorCode;
+import umc.stockoneqback.user.exception.UserErrorCode;
 
 import java.nio.charset.StandardCharsets;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -29,9 +35,10 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static umc.stockoneqback.common.DocumentFormatGenerator.getInputDTOFormat;
-import static umc.stockoneqback.common.DocumentFormatGenerator.getInputImageFormat;
+import static umc.stockoneqback.common.DocumentFormatGenerator.*;
+import static umc.stockoneqback.common.DocumentFormatGenerator.getDateFormat;
 import static umc.stockoneqback.fixture.BoardFixture.BOARD_0;
+import static umc.stockoneqback.fixture.ProductFixture.APPLE;
 import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
 import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
 
@@ -82,7 +89,6 @@ public class BoardApiControllerTest extends ControllerTest {
                                     requestPartFields(
                                             "request",
                                             fieldWithPath("title").description("등록할 제목"),
-                                            fieldWithPath("file").description("등록할 파일"),
                                             fieldWithPath("content").description("등록할 내용")
                                     ),
                                     responseFields(
@@ -134,7 +140,6 @@ public class BoardApiControllerTest extends ControllerTest {
                                     requestPartFields(
                                             "request",
                                             fieldWithPath("title").description("등록할 제목"),
-                                            fieldWithPath("file").description("등록할 파일"),
                                             fieldWithPath("content").description("등록할 내용")
                                     )
                             )
@@ -199,7 +204,6 @@ public class BoardApiControllerTest extends ControllerTest {
                                     requestPartFields(
                                             "request",
                                             fieldWithPath("title").description("수정할 제목"),
-                                            fieldWithPath("file").description("수정할 파일"),
                                             fieldWithPath("content").description("수정할 내용")
                                     ),
                                     responseFields(
@@ -270,7 +274,6 @@ public class BoardApiControllerTest extends ControllerTest {
                                     requestPartFields(
                                             "request",
                                             fieldWithPath("title").description("수정할 제목"),
-                                            fieldWithPath("file").description("수정할 파일"),
                                             fieldWithPath("content").description("수정할 내용")
                                     ),
                                     responseFields(
@@ -332,7 +335,6 @@ public class BoardApiControllerTest extends ControllerTest {
                                     requestPartFields(
                                             "request",
                                             fieldWithPath("title").description("수정할 제목"),
-                                            fieldWithPath("file").description("수정할 파일"),
                                             fieldWithPath("content").description("수정할 내용")
                                     )
                             )
@@ -508,8 +510,104 @@ public class BoardApiControllerTest extends ControllerTest {
         }
     }
 
+    @Nested
+    @DisplayName("게시글 상세조회 API [GET /api/boards/{boardId}]")
+    class getDetailBoard {
+        private static final String BASE_URL = "/api/boards/{boardId}";
+        private static final Long USER_ID = 1L;
+        private static final Long BOARD_ID = 2L;
+
+        @Test
+        @DisplayName("유효하지 않은 권한으로 게시글 상세 조회 시 실패한다")
+        void throwExceptionInvalid_User_JWT() throws Exception {
+            // given
+            doThrow(BaseException.type(GlobalErrorCode.INVALID_USER_JWT))
+                    .when(boardService)
+                    .loadBoard(anyLong(), anyLong());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL, BOARD_ID)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+
+            // then
+            final GlobalErrorCode expectedError = GlobalErrorCode.INVALID_USER_JWT;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isForbidden(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "BoardApi/Detail/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    pathParameters(
+                                            parameterWithName("boardId").description("상세조회할 게시글 ID")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("게시글 상세조회에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(loadBoardResponse())
+                    .when(boardService)
+                    .loadBoard(anyLong(), anyLong());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL, BOARD_ID)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(status().isOk())
+                    .andDo(
+                            document(
+                                    "BoardApi/Detail/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    pathParameters(
+                                            parameterWithName("boardId").description("상세조회할 게시글 ID")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("id").type(JsonFieldType.NUMBER).description("상세조회한 게시글 ID"),
+                                            fieldWithPath("title").type(JsonFieldType.STRING).description("상세조회한 제목"),
+                                            fieldWithPath("file").type(JsonFieldType.ARRAY).description("상세조회한 파일").optional(),
+                                            fieldWithPath("content").type(JsonFieldType.STRING).description("상세조회한 내용")
+                                    )
+                            )
+                    );
+
+        }
+    }
+
     private BoardRequest createBoardRequest() {
-        return new BoardRequest(BOARD_0.getTitle(), BOARD_0.getFile(), BOARD_0.getContent());
+        return new BoardRequest(BOARD_0.getTitle(), BOARD_0.getContent());
+    }
+
+    private BoardResponse loadBoardResponse() {
+        return new BoardResponse(1L, BOARD_0.getTitle(), null ,BOARD_0.getContent());
     }
 }
 


### PR DESCRIPTION
## Summary 📌
커뮤니티 게시글 세부 조회 API를 구현한다
## Describe your changes 📝
* 커뮤니티 게시글 세부 조회 API 구현
   * BoardApiController
       * loadBoard() 
   * BoardService
       * loadBoard()  
    * BoardResponse
* 테스트 코드
   * BoardApiControllerTest
* board.adoc 수정 (게시글 상세조회 추가)
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️

## Issue numbers and link 🚪
Closes #38 
