### PR TITLE
[Fix] 자격증명이 없어도 되는 uri를 security config에 추가한다

### DIFF
--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -24,6 +24,15 @@ HTTP Response
 include::{snippets}/UserApi/SignUp/Manager/Failure/Case2/http-response.adoc[]
 include::{snippets}/UserApi/SignUp/Manager/Failure/Case2/response-fields.adoc[]
 
+=== 2. 중복된 이메일이 존재한다면 가게 사장님 등록에 실패한다
+HTTP Request
+include::{snippets}/UserApi/SignUp/Manager/Failure/Case3/http-request.adoc[]
+include::{snippets}/UserApi/SignUp/Manager/Failure/Case3/request-body.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/SignUp/Manager/Failure/Case3/http-response.adoc[]
+include::{snippets}/UserApi/SignUp/Manager/Failure/Case3/response-fields.adoc[]
+
 === 3. 가게 사장님 등록에 성공한다
 HTTP Request
 include::{snippets}/UserApi/SignUp/Manager/Success/http-request.adoc[]
@@ -42,7 +51,7 @@ HTTP Response
 include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case1/http-response.adoc[]
 include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case1/response-fields.adoc[]
 
-=== 2. 가게 코드가 일치하지 않으면 아르바이트생 등록에 실패한다
+=== 2. 중복된 이메일이 있다면 아르바이트생 등록에 실패한다
 HTTP Request
 include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case2/http-request.adoc[]
 include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case2/request-body.adoc[]
@@ -50,6 +59,15 @@ include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case2/request-body.adoc[]
 HTTP Response
 include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case2/http-response.adoc[]
 include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case2/response-fields.adoc[]
+
+=== 3. 가게 코드가 일치하지 않으면 아르바이트생 등록에 실패한다
+HTTP Request
+include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case3/http-request.adoc[]
+include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case3/request-body.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case3/http-response.adoc[]
+include::{snippets}/UserApi/SignUp/PartTimer/Failure/Case3/response-fields.adoc[]
 
 === 3. 아르바이트생 등록에 성공한다
 HTTP Request
@@ -69,7 +87,7 @@ HTTP Response
 include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case1/http-response.adoc[]
 include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case1/response-fields.adoc[]
 
-=== 2. 회사 코드가 일치하지 않으면 슈퍼바이저 등록에 실패한다
+=== 2. 중복된 이메일이 있다면 슈퍼바이저 등록에 실패한다
 HTTP Request
 include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case2/http-request.adoc[]
 include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case2/request-body.adoc[]
@@ -77,6 +95,15 @@ include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case2/request-body.adoc[]
 HTTP Response
 include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case2/http-response.adoc[]
 include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case2/response-fields.adoc[]
+
+=== 3. 회사 코드가 일치하지 않으면 슈퍼바이저 등록에 실패한다
+HTTP Request
+include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case3/http-request.adoc[]
+include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case3/request-body.adoc[]
+
+HTTP Response
+include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case3/http-response.adoc[]
+include::{snippets}/UserApi/SignUp/Supervisor/Failure/Case3/response-fields.adoc[]
 
 === 3. 슈퍼바이저 등록에 성공한다
 HTTP Request

--- a/src/main/java/umc/stockoneqback/global/security/SecurityConfig.java
+++ b/src/main/java/umc/stockoneqback/global/security/SecurityConfig.java
@@ -54,6 +54,8 @@ public class SecurityConfig {
                     .antMatchers("/api/user/sign-up/manager").permitAll()
                     .antMatchers("/api/user/sign-up/part-timer").permitAll()
                     .antMatchers("/api/user/sign-up/supervisor").permitAll()
+                    .antMatchers("/api/user/update/password").permitAll()
+                    .antMatchers("/api/user/find-id").permitAll()
                 .anyRequest().authenticated();
 
         http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/umc/stockoneqback/user/controller/dto/request/FindLoginIdRequest.java
+++ b/src/main/java/umc/stockoneqback/user/controller/dto/request/FindLoginIdRequest.java
@@ -1,5 +1,7 @@
 package umc.stockoneqback.user.controller.dto.request;
 
+import org.springframework.format.annotation.DateTimeFormat;
+
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -9,6 +11,7 @@ public record FindLoginIdRequest(
         String name,
 
         @NotNull(message = "생일은 필수입니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
         LocalDate birth,
 
         @NotBlank(message = "이메일은 필수입니다.")

--- a/src/main/java/umc/stockoneqback/user/controller/dto/request/ValidateUpdatePasswordRequest.java
+++ b/src/main/java/umc/stockoneqback/user/controller/dto/request/ValidateUpdatePasswordRequest.java
@@ -1,5 +1,7 @@
 package umc.stockoneqback.user.controller.dto.request;
 
+import org.springframework.format.annotation.DateTimeFormat;
+
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -9,6 +11,7 @@ public record ValidateUpdatePasswordRequest(
         String name,
 
         @NotNull(message = "생일은 필수입니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
         LocalDate birth,
 
         @NotBlank(message = "로그인 아이디는 필수입니다.")

--- a/src/main/java/umc/stockoneqback/user/domain/UserRepository.java
+++ b/src/main/java/umc/stockoneqback/user/domain/UserRepository.java
@@ -10,5 +10,4 @@ public interface UserRepository extends JpaRepository<User, Long>, UserFindQuery
     boolean existsByEmail(Email email);
     Optional<User> findByLoginId(String loginId);
     Optional<User> findByEmail(Email email);
-    boolean existsByEmail(Email email);
 }

--- a/src/test/java/umc/stockoneqback/friend/controller/FriendApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/friend/controller/FriendApiControllerTest.java
@@ -298,11 +298,11 @@ class FriendApiControllerTest extends ControllerTest {
             given(jwtTokenProvider.getId(anyString())).willReturn(SENDER_ID);
             doThrow(BaseException.type(FriendErrorCode.FRIEND_NOT_FOUND))
                     .when(friendService)
-                    .requestFriend(SENDER_ID, RECEIVER_ID);
+                    .cancelFriend(SENDER_ID, RECEIVER_ID);
 
             // when
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
-                    .post(BASE_URL, RECEIVER_ID)
+                    .delete(BASE_URL, RECEIVER_ID)
                     .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
 
             // then
@@ -345,11 +345,11 @@ class FriendApiControllerTest extends ControllerTest {
             given(jwtTokenProvider.getId(anyString())).willReturn(SENDER_ID);
             doThrow(BaseException.type(FriendErrorCode.STATUS_IS_ACCEPT))
                     .when(friendService)
-                    .requestFriend(SENDER_ID, RECEIVER_ID);
+                    .cancelFriend(SENDER_ID, RECEIVER_ID);
 
             // when
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
-                    .post(BASE_URL, RECEIVER_ID)
+                    .delete(BASE_URL, RECEIVER_ID)
                     .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
 
             // then
@@ -396,7 +396,7 @@ class FriendApiControllerTest extends ControllerTest {
 
             // when
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
-                    .post(BASE_URL, RECEIVER_ID)
+                    .delete(BASE_URL, RECEIVER_ID)
                     .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
 
             // then

--- a/src/test/java/umc/stockoneqback/user/controller/UserApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/user/controller/UserApiControllerTest.java
@@ -144,6 +144,61 @@ class UserApiControllerTest extends ControllerTest {
         }
 
         @Test
+        @DisplayName("중복된 이메일이 존재한다면 가게 사장님 등록에 실패한다")
+        void throwExceptionByDuplicateEmail() throws Exception {
+            // given
+            doReturn(STORE_ID)
+                    .when(storeService)
+                    .save(anyString(), anyString(), anyString());
+            doThrow(BaseException.type(UserErrorCode.DUPLICATE_LOGIN_ID))
+                    .when(userService)
+                    .saveManager(any(), anyLong());
+
+            // when
+            final SignUpManagerRequest request = createSignUpManagerRequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL)
+                    .with(csrf())
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request));
+
+            // then
+            final UserErrorCode expectedError = UserErrorCode.DUPLICATE_LOGIN_ID;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isConflict(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "UserApi/SignUp/Manager/Failure/Case3",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestFields(
+                                            fieldWithPath("name").description("이름"),
+                                            fieldWithPath("birth").description("생일"),
+                                            fieldWithPath("email").description("이메일"),
+                                            fieldWithPath("loginId").description("아이디"),
+                                            fieldWithPath("password").description("비밀번호"),
+                                            fieldWithPath("phoneNumber").description("전화번호"),
+                                            fieldWithPath("storeName").description("가게 이름"),
+                                            fieldWithPath("storeSector").description("가게 업종"),
+                                            fieldWithPath("storeAddress").description("가게 주소")                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
         @DisplayName("가게 사장님 등록에 성공한다")
         @WithMockUser
         void success() throws Exception {
@@ -248,6 +303,58 @@ class UserApiControllerTest extends ControllerTest {
         }
 
         @Test
+        @DisplayName("중복된 이메일이 있다면 아르바이트생 등록에 실패한다")
+        void throwExceptionByDuplicateEmail() throws Exception {
+            // given
+            doThrow(BaseException.type(UserErrorCode.DUPLICATE_EMAIL))
+                    .when(userService)
+                    .savePartTimer(any(), anyString(), anyString());
+
+            // when
+            final SignUpPartTimerRequest request = createSignUpPartTimerRequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL)
+                    .with(csrf())
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request));
+
+            // then
+            final UserErrorCode expectedError = UserErrorCode.DUPLICATE_EMAIL;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isConflict(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "UserApi/SignUp/PartTimer/Failure/Case2",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestFields(
+                                            fieldWithPath("name").description("이름"),
+                                            fieldWithPath("birth").description("생일"),
+                                            fieldWithPath("email").description("이메일"),
+                                            fieldWithPath("loginId").description("아이디"),
+                                            fieldWithPath("password").description("비밀번호"),
+                                            fieldWithPath("phoneNumber").description("전화번호"),
+                                            fieldWithPath("storeName").description("가게 이름"),
+                                            fieldWithPath("storeCode").description("가게 코드")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
         @DisplayName("가게 코드가 일치하지 않으면 아르바이트생 등록에 실패한다")
         void throwExceptionByInvalidStoreCode() throws Exception {
             // given
@@ -277,7 +384,7 @@ class UserApiControllerTest extends ControllerTest {
                     )
                     .andDo(
                             document(
-                                    "UserApi/SignUp/PartTimer/Failure/Case2",
+                                    "UserApi/SignUp/PartTimer/Failure/Case3",
                                     preprocessRequest(prettyPrint()),
                                     preprocessResponse(prettyPrint()),
                                     requestFields(
@@ -399,6 +506,58 @@ class UserApiControllerTest extends ControllerTest {
         }
 
         @Test
+        @DisplayName("중복된 이메일이 있다면 슈퍼바이저 등록에 실패한다")
+        void throwExceptionByDuplicateEmail() throws Exception {
+            // given
+            doThrow(BaseException.type(UserErrorCode.DUPLICATE_EMAIL))
+                    .when(userService)
+                    .saveSupervisor(any(), anyString(), anyString());
+
+            // when
+            final SignUpSupervisorRequest request = createSignUpSupervisorRequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL)
+                    .with(csrf())
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request));
+
+            // then
+            final UserErrorCode expectedError = UserErrorCode.DUPLICATE_EMAIL;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isConflict(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "UserApi/SignUp/Supervisor/Failure/Case2",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestFields(
+                                            fieldWithPath("name").description("이름"),
+                                            fieldWithPath("birth").description("생일"),
+                                            fieldWithPath("email").description("이메일"),
+                                            fieldWithPath("loginId").description("아이디"),
+                                            fieldWithPath("password").description("비밀번호"),
+                                            fieldWithPath("phoneNumber").description("전화번호"),
+                                            fieldWithPath("companyName").description("회사 이름"),
+                                            fieldWithPath("companyCode").description("회사 코드")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
         @DisplayName("회사 코드가 일치하지 않으면 슈퍼바이저 등록에 실패한다")
         void throwExceptionByInvalidCompanyCode() throws Exception {
             // given
@@ -428,7 +587,7 @@ class UserApiControllerTest extends ControllerTest {
                     )
                     .andDo(
                             document(
-                                    "UserApi/SignUp/Supervisor/Failure/Case2",
+                                    "UserApi/SignUp/Supervisor/Failure/Case3",
                                     preprocessRequest(prettyPrint()),
                                     preprocessResponse(prettyPrint()),
                                     requestFields(


### PR DESCRIPTION
## Summary 📌
- 자격증명이 없어도 되는 uri를 security config에 추가한다

## Describe your changes 📝
- security config 수정
- 중복된 이메일 검증에 대한 테스트 코드 추가
- FriendApiController test 추가

## Check list ✅
- [X] I write PR according to the form
- [X] All tests are passed
- [X] Program works normally
- [X] I set proper PR labels
- [X] I remove any redundant codes

## Issue numbers and link 🚪
Closes #94 
