### PR TITLE
[Feat] 게시글 상세조회에 사용되는 BoardResponse를 수정한다

### DIFF
--- a/src/main/java/umc/stockoneqback/board/controller/dto/BoardResponse.java
+++ b/src/main/java/umc/stockoneqback/board/controller/dto/BoardResponse.java
@@ -10,6 +10,8 @@ public record BoardResponse(
 
         byte[] file,
 
-        String content
+        String content,
+
+        String writer
 ) {
 }

--- a/src/main/java/umc/stockoneqback/board/controller/dto/BoardResponse.java
+++ b/src/main/java/umc/stockoneqback/board/controller/dto/BoardResponse.java
@@ -2,6 +2,8 @@ package umc.stockoneqback.board.controller.dto;
 
 import lombok.Builder;
 
+import java.time.LocalDateTime;
+
 @Builder
 public record BoardResponse(
         Long id,
@@ -11,6 +13,12 @@ public record BoardResponse(
         byte[] file,
 
         String content,
+
+        int hit,
+
+        int likes,
+
+        LocalDateTime createdDate,
 
         String writer
 ) {

--- a/src/main/java/umc/stockoneqback/board/service/BoardService.java
+++ b/src/main/java/umc/stockoneqback/board/service/BoardService.java
@@ -67,6 +67,7 @@ public class BoardService {
                 .title(board.getTitle())
                 .file(file)
                 .content(board.getContent())
+                .writer(board.getWriter().getLoginId())
                 .build();
     }
 

--- a/src/main/java/umc/stockoneqback/board/service/BoardService.java
+++ b/src/main/java/umc/stockoneqback/board/service/BoardService.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 import umc.stockoneqback.board.controller.dto.BoardResponse;
 import umc.stockoneqback.board.domain.Board;
 import umc.stockoneqback.board.domain.BoardRepository;
+import umc.stockoneqback.board.domain.like.BoardLikeRepository;
 import umc.stockoneqback.board.exception.BoardErrorCode;
 import umc.stockoneqback.file.service.FileService;
 import umc.stockoneqback.global.base.BaseException;
@@ -25,6 +26,7 @@ public class BoardService {
     private final BoardFindService boardFindService;
     private final BoardRepository boardRepository;
     private final FileService fileService;
+    private final BoardLikeRepository boardLikeRepository;
 
     @Transactional
     public Long create(Long writerId, String title, MultipartFile file, String content){
@@ -67,6 +69,9 @@ public class BoardService {
                 .title(board.getTitle())
                 .file(file)
                 .content(board.getContent())
+                .hit(board.getHit())
+                .likes(boardLikeRepository.countByBoard(board))
+                .createdDate(board.getCreatedDate())
                 .writer(board.getWriter().getLoginId())
                 .build();
     }

--- a/src/main/java/umc/stockoneqback/user/domain/UserRepository.java
+++ b/src/main/java/umc/stockoneqback/user/domain/UserRepository.java
@@ -10,5 +10,4 @@ public interface UserRepository extends JpaRepository<User, Long>, UserFindQuery
     boolean existsByEmail(Email email);
     Optional<User> findByLoginId(String loginId);
     Optional<User> findByEmail(Email email);
-    boolean existsByEmail(Email email);
 }

--- a/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/board/controller/BoardApiControllerTest.java
@@ -18,6 +18,7 @@ import umc.stockoneqback.global.base.BaseException;
 import umc.stockoneqback.global.base.GlobalErrorCode;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -37,6 +38,7 @@ import static umc.stockoneqback.common.DocumentFormatGenerator.*;
 import static umc.stockoneqback.fixture.BoardFixture.BOARD_0;
 import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
 import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
+import static umc.stockoneqback.fixture.UserFixture.SAEWOO;
 
 @DisplayName("Board [Controller Layer] -> BoardApiController 테스트")
 public class BoardApiControllerTest extends ControllerTest {
@@ -590,7 +592,11 @@ public class BoardApiControllerTest extends ControllerTest {
                                             fieldWithPath("id").type(JsonFieldType.NUMBER).description("상세조회한 게시글 ID"),
                                             fieldWithPath("title").type(JsonFieldType.STRING).description("상세조회한 제목"),
                                             fieldWithPath("file").type(JsonFieldType.ARRAY).description("상세조회한 파일").optional(),
-                                            fieldWithPath("content").type(JsonFieldType.STRING).description("상세조회한 내용")
+                                            fieldWithPath("content").type(JsonFieldType.STRING).description("상세조회한 내용"),
+                                            fieldWithPath("hit").type(JsonFieldType.NUMBER).description("상세조회한 조회수"),
+                                            fieldWithPath("likes").type(JsonFieldType.NUMBER).description("상세조회한 좋아요수"),
+                                            fieldWithPath("createdDate").type(JsonFieldType.STRING).description("상세조회한 등록일"),
+                                            fieldWithPath("writer").type(JsonFieldType.STRING).description("상세조회한 작성자")
                                     )
                             )
                     );
@@ -603,7 +609,8 @@ public class BoardApiControllerTest extends ControllerTest {
     }
 
     private BoardResponse loadBoardResponse() {
-        return new BoardResponse(1L, BOARD_0.getTitle(), null ,BOARD_0.getContent());
+        return new BoardResponse(1L, BOARD_0.getTitle(), null ,BOARD_0.getContent(), BOARD_0.getHit(), 0,
+                LocalDate.of(2023, 7, 22).atTime(1, 1) ,SAEWOO.toUser().getLoginId());
     }
 }
 


### PR DESCRIPTION
## Summary 📌
게시글 상세조회에 사용되는 BoardResponse를 수정한다
## Describe your changes 📝
* BoardResponse 수정
    * hit, likes, createdDate, writer(userId)   
* BoardApiController 수정 
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️

## Issue numbers and link 🚪
Closes #97
