### PR TITLE
[Feat] F&A 게시판 조회 API를 구현한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,10 @@ dependencies {
 
     // validation (add)
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Redis (add)
+    implementation 'it.ozimov:embedded-redis:0.7.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 ext {

--- a/src/docs/asciidoc/admin-static.adoc
+++ b/src/docs/asciidoc/admin-static.adoc
@@ -1,0 +1,43 @@
+= ADMIN STATIC 관리자 정적 페이지 관리 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+
+== 공통 예외
+=== 1. 권한이 없는 사용자가 Admin API를 호출한 경우 API 호출에 실패한다
+==== HTTP Request
+include::{snippets}/AdminStaticApi/CommonError/Case1/http-request.adoc[]
+Request Header
+include::{snippets}/AdminStaticApi/CommonError/Case1/request-headers.adoc[]
+Request Parameter
+include::{snippets}/AdminStaticApi/CommonError/Case1/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/AdminStaticApi/CommonError/Case1/http-response.adoc[]
+include::{snippets}/AdminStaticApi/CommonError/Case1/response-fields.adoc[]
+
+== F&A 추가
+=== 1. F&A 추가에 성공한다
+==== HTTP Request
+include::{snippets}/AdminStaticApi/AddFA/Success/http-request.adoc[]
+Request Header
+include::{snippets}/AdminStaticApi/AddFA/Success/request-headers.adoc[]
+Request Body
+include::{snippets}/AdminStaticApi/AddFA/Success/request-body.adoc[]
+
+==== HTTP Response
+include::{snippets}/AdminStaticApi/AddFA/Success/http-response.adoc[]
+
+== F&A 삭제
+=== 1. F&A 삭제에 성공한다
+==== HTTP Request
+include::{snippets}/AdminStaticApi/DeleteFA/Success/http-request.adoc[]
+Request Header
+include::{snippets}/AdminStaticApi/DeleteFA/Success/request-headers.adoc[]
+Request Parameter
+include::{snippets}/AdminStaticApi/DeleteFA/Success/request-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/AdminStaticApi/DeleteFA/Success/http-response.adoc[]

--- a/src/docs/asciidoc/user-fa.adoc
+++ b/src/docs/asciidoc/user-fa.adoc
@@ -1,0 +1,17 @@
+= USER F&A API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+
+== 사용자 F&A 조회 (10.2)
+=== 1. 사용자 F&A 조회에 성공한다
+==== HTTP Request
+include::{snippets}/UserFAApi/GetFAList/Success/http-request.adoc[]
+Request Header
+include::{snippets}/UserFAApi/GetFAList/Success/request-headers.adoc[]
+
+==== HTTP Response
+include::{snippets}/UserFAApi/GetFAList/Success/http-response.adoc[]
+include::{snippets}/UserFAApi/GetFAList/Success/response-fields.adoc[]

--- a/src/main/java/umc/stockoneqback/admin/controller/AdminStaticApiController.java
+++ b/src/main/java/umc/stockoneqback/admin/controller/AdminStaticApiController.java
@@ -12,7 +12,7 @@ import javax.validation.Valid;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
-public class AdminStaticController {
+public class AdminStaticApiController {
     private final AdminStaticService adminStaticService;
 
     @PostMapping("/fa")

--- a/src/main/java/umc/stockoneqback/admin/controller/AdminStaticController.java
+++ b/src/main/java/umc/stockoneqback/admin/controller/AdminStaticController.java
@@ -1,0 +1,31 @@
+package umc.stockoneqback.admin.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import umc.stockoneqback.admin.dto.request.AddFARequest;
+import umc.stockoneqback.admin.service.AdminStaticService;
+import umc.stockoneqback.global.annotation.ExtractPayload;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminStaticController {
+    private final AdminStaticService adminStaticService;
+
+    @PostMapping("/fa")
+    public ResponseEntity<Void> addFA(@ExtractPayload Long userId,
+                                      @Valid @RequestBody AddFARequest addFARequest) {
+        adminStaticService.addFA(userId, addFARequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/fa")
+    public ResponseEntity<Void> deleteFA(@ExtractPayload Long userId,
+                                      @RequestParam(value = "question") String question) {
+        adminStaticService.deleteFA(userId, question);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/umc/stockoneqback/admin/domain/StaticFA.java
+++ b/src/main/java/umc/stockoneqback/admin/domain/StaticFA.java
@@ -1,0 +1,28 @@
+package umc.stockoneqback.admin.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+import javax.persistence.Id;
+
+@Getter
+@RedisHash("staticFa")
+@AllArgsConstructor
+@Builder
+public class StaticFA {
+    @Id
+    private String id;
+
+    @Indexed
+    private String answer;
+
+    public static StaticFA createStaticFa(String question, String answer) {
+        return StaticFA.builder()
+                .id(question)
+                .answer(answer)
+                .build();
+    }
+}

--- a/src/main/java/umc/stockoneqback/admin/domain/StaticFARedisRepository.java
+++ b/src/main/java/umc/stockoneqback/admin/domain/StaticFARedisRepository.java
@@ -1,0 +1,10 @@
+package umc.stockoneqback.admin.domain;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface StaticFARedisRepository extends CrudRepository<StaticFA, String> {
+    @Override
+    List<StaticFA> findAll();
+}

--- a/src/main/java/umc/stockoneqback/admin/dto/request/AddFARequest.java
+++ b/src/main/java/umc/stockoneqback/admin/dto/request/AddFARequest.java
@@ -1,0 +1,19 @@
+package umc.stockoneqback.admin.dto.request;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+public record AddFARequest(
+        @NotNull @Valid
+        List<AddFAKeyValue> addFAKeyValueList
+) {
+    public record AddFAKeyValue(
+            @NotBlank
+            String question,
+
+            @NotBlank
+            String answer
+    ){}
+}

--- a/src/main/java/umc/stockoneqback/admin/service/AdminStaticService.java
+++ b/src/main/java/umc/stockoneqback/admin/service/AdminStaticService.java
@@ -7,9 +7,9 @@ import umc.stockoneqback.admin.domain.StaticFA;
 import umc.stockoneqback.admin.domain.StaticFARedisRepository;
 import umc.stockoneqback.admin.dto.request.AddFARequest;
 import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.global.base.GlobalErrorCode;
 import umc.stockoneqback.user.domain.Role;
 import umc.stockoneqback.user.domain.User;
-import umc.stockoneqback.user.exception.UserErrorCode;
 import umc.stockoneqback.user.service.UserFindService;
 
 @Service
@@ -39,6 +39,6 @@ public class AdminStaticService {
         User user = userFindService.findById(userId);
         if (user.getRole() == Role.ADMINISTRATOR)
             return;
-        throw BaseException.type(UserErrorCode.ROLE_NOT_FOUND);
+        throw BaseException.type(GlobalErrorCode.NOT_FOUND);
     }
 }

--- a/src/main/java/umc/stockoneqback/admin/service/AdminStaticService.java
+++ b/src/main/java/umc/stockoneqback/admin/service/AdminStaticService.java
@@ -1,0 +1,44 @@
+package umc.stockoneqback.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.admin.domain.StaticFA;
+import umc.stockoneqback.admin.domain.StaticFARedisRepository;
+import umc.stockoneqback.admin.dto.request.AddFARequest;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.user.domain.Role;
+import umc.stockoneqback.user.domain.User;
+import umc.stockoneqback.user.exception.UserErrorCode;
+import umc.stockoneqback.user.service.UserFindService;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminStaticService {
+    private final UserFindService userFindService;
+    private final StaticFARedisRepository staticFARedisRepository;
+    @Transactional
+    public void addFA(Long userId, AddFARequest addFARequest) {
+        isAdministrator(userId);
+        for (AddFARequest.AddFAKeyValue addFAKeyValue : addFARequest.addFAKeyValueList()) {
+            staticFARedisRepository.save(StaticFA.builder()
+                                                    .id(addFAKeyValue.question())
+                                                    .answer(addFAKeyValue.answer())
+                                                    .build());
+        }
+    }
+
+    @Transactional
+    public void deleteFA(Long userId, String question) {
+        isAdministrator(userId);
+        staticFARedisRepository.deleteById(question);
+    }
+
+    private void isAdministrator(Long userId) {
+        User user = userFindService.findById(userId);
+        if (user.getRole() == Role.ADMINISTRATOR)
+            return;
+        throw BaseException.type(UserErrorCode.ROLE_NOT_FOUND);
+    }
+}

--- a/src/main/java/umc/stockoneqback/global/config/RedisConfig.java
+++ b/src/main/java/umc/stockoneqback/global/config/RedisConfig.java
@@ -1,0 +1,51 @@
+package umc.stockoneqback.global.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
+@Configuration
+@EnableCaching
+public class RedisConfig {
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory){
+        RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()
+                .computePrefixWith(CacheKeyPrefix.simple())
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(new StringRedisSerializer()))
+
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+
+        // 캐시키 별 default 유효시간 설정
+        Map<String, RedisCacheConfiguration> cacheConfiguration = new HashMap<>();
+        /*
+        cacheConfiguration.put(CacheKey.ZONE, RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofSeconds(CacheKey.ZONE_EXPIRE_SEC)));
+         */
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(configuration)
+                .withInitialCacheConfigurations(cacheConfiguration)
+                .build();
+    }
+}

--- a/src/main/java/umc/stockoneqback/user/controller/UserFAApiController.java
+++ b/src/main/java/umc/stockoneqback/user/controller/UserFAApiController.java
@@ -14,7 +14,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
-public class UserFAController {
+public class UserFAApiController {
     private final UserFAService userFAService;
 
     @GetMapping("/fa")

--- a/src/main/java/umc/stockoneqback/user/controller/UserFAController.java
+++ b/src/main/java/umc/stockoneqback/user/controller/UserFAController.java
@@ -1,0 +1,24 @@
+package umc.stockoneqback.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.stockoneqback.global.annotation.ExtractPayload;
+import umc.stockoneqback.global.base.BaseResponse;
+import umc.stockoneqback.user.service.UserFAService;
+import umc.stockoneqback.user.service.dto.response.GetFAResponse;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserFAController {
+    private final UserFAService userFAService;
+
+    @GetMapping("/fa")
+    public BaseResponse<List<GetFAResponse>> getFA(@ExtractPayload Long userId) {
+        return new BaseResponse<>(userFAService.getFA());
+    }
+}

--- a/src/main/java/umc/stockoneqback/user/domain/Role.java
+++ b/src/main/java/umc/stockoneqback/user/domain/Role.java
@@ -10,7 +10,8 @@ import umc.stockoneqback.global.utils.EnumStandard;
 public enum Role implements EnumStandard {
     MANAGER("ROLE_MANAGER", "사장님"),
     PART_TIMER("ROLE_PART_TIMER", "아르바이트생"),
-    SUPERVISOR("ROLE_SUPERVISOR", "슈퍼바이저")
+    SUPERVISOR("ROLE_SUPERVISOR", "슈퍼바이저"),
+    ADMINISTRATOR("ROLE_ADMINISTRATOR", "관리자"),
     ;
 
     private final String authority;

--- a/src/main/java/umc/stockoneqback/user/service/UserFAService.java
+++ b/src/main/java/umc/stockoneqback/user/service/UserFAService.java
@@ -1,0 +1,31 @@
+package umc.stockoneqback.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.admin.domain.StaticFA;
+import umc.stockoneqback.admin.domain.StaticFARedisRepository;
+import umc.stockoneqback.user.service.dto.response.GetFAResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserFAService {
+    private final StaticFARedisRepository staticFARedisRepository;
+
+    @Transactional
+    public List<GetFAResponse> getFA() {
+        List<StaticFA> staticFAList = staticFARedisRepository.findAll();
+        List<GetFAResponse> getFAResponseList = new ArrayList<>();
+        for (StaticFA staticFA: staticFAList) {
+            getFAResponseList.add(GetFAResponse.builder()
+                                                .question(staticFA.getId())
+                                                .answer(staticFA.getAnswer())
+                                                .build());
+        }
+        return getFAResponseList;
+    }
+}

--- a/src/main/java/umc/stockoneqback/user/service/UserFAService.java
+++ b/src/main/java/umc/stockoneqback/user/service/UserFAService.java
@@ -10,6 +10,8 @@ import umc.stockoneqback.user.service.dto.response.GetFAResponse;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.Comparator.comparing;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -19,6 +21,7 @@ public class UserFAService {
     @Transactional
     public List<GetFAResponse> getFA() {
         List<StaticFA> staticFAList = staticFARedisRepository.findAll();
+        staticFAList.sort(comparing(StaticFA::getId));
         List<GetFAResponse> getFAResponseList = new ArrayList<>();
         for (StaticFA staticFA: staticFAList) {
             getFAResponseList.add(GetFAResponse.builder()

--- a/src/main/java/umc/stockoneqback/user/service/dto/response/GetFAResponse.java
+++ b/src/main/java/umc/stockoneqback/user/service/dto/response/GetFAResponse.java
@@ -1,0 +1,11 @@
+package umc.stockoneqback.user.service.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record GetFAResponse(
+        String question,
+
+        String answer
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,12 @@ spring:
     import:
       - classpath:secret.yml
 
+  cache:
+    type: redis
+  redis:
+    host: 127.0.0.1
+    port: 6379
+
 logging:
   level:
     com:

--- a/src/test/java/umc/stockoneqback/admin/controller/AdminStaticApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/admin/controller/AdminStaticApiControllerTest.java
@@ -1,0 +1,180 @@
+package umc.stockoneqback.admin.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import umc.stockoneqback.admin.dto.request.AddFARequest;
+import umc.stockoneqback.common.ControllerTest;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.global.base.GlobalErrorCode;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static umc.stockoneqback.fixture.TokenFixture.*;
+
+@DisplayName("Admin [Controller Layer] -> AdminStaticApiController 테스트")
+public class AdminStaticApiControllerTest extends ControllerTest {
+    private final List<String> questionList = Arrays.asList(
+            "Q1. 슈퍼바이저가 다른 프랜차이즈로 이직할 경우 회원정보는 어떻게 변경하나요?",
+            "Q2. 알바생이랑 슈퍼바이저는 어떤 기능을 사용할 수 있나요?",
+            "Q3. 전 개인 카페 자영업자인데 Connect 서비스를 이용하지 못하는 것인가요?"
+    );
+    private final List<String> answerList = Arrays.asList(
+            "A1. 이직하는 프랜차이즈의 발급코드가 필요하기 때문에 탈퇴하고 다시 회원가입을 진행해주셔야 합니다.",
+            "A2. 알바생은 사장님과 동일하게 Home(재고 관리), Connect, 마이페이지 메뉴를 이용할 수 있고, " +
+                    "슈퍼바이저는 Connect와 마이페이지 메뉴를 이용할 수 있습니다.",
+            "A3. 네, 아쉽지만 해당 슈퍼바이저와 연결되는 Connect 서비스를 이용할 수 없습니다. " +
+                    "하지만, 재고 관리 기능과 Community 기능을 이용해 카페 운영을 원활하게 할 수 있습니다."
+    );
+
+    @Nested
+    @DisplayName("공통 예외")
+    class commonError {
+        private static final String BASE_URL = "/api/admin/fa";
+
+        @Test
+        @DisplayName("권한이 없는 사용자가 Admin API를 호출한 경우 API 호출에 실패한다")
+        void throwExceptionByUnauthorizedUser() throws Exception {
+            // given
+            doThrow(BaseException.type(GlobalErrorCode.NOT_FOUND))
+                    .when(adminStaticService)
+                    .deleteFA(anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .delete(BASE_URL)
+                    .param("question", questionList.get(0))
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            final GlobalErrorCode expectedError = GlobalErrorCode.NOT_FOUND;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "AdminStaticApi/CommonError/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestParameters(
+                                            parameterWithName("question").description("삭제할 질문")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("F&A 추가 API [POST /api/admin/fa]")
+    class addFA {
+        private static final String BASE_URL = "/api/admin/fa";
+
+        @Test
+        @DisplayName("F&A 추가에 성공한다")
+        void success() throws Exception {
+            // given
+            doNothing()
+                    .when(adminStaticService)
+                    .addFA(anyLong(), any());
+
+            // when
+            final AddFARequest addFARequest = createAddFARequest();
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL)
+                    .with(csrf())
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(addFARequest))
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpect(
+                            status().isOk()
+                    )
+                    .andDo(
+                            document(
+                                    "AdminStaticApi/AddFA/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestFields(
+                                            fieldWithPath("addFAKeyValueList[].question").description("질문"),
+                                            fieldWithPath("addFAKeyValueList[].answer").description("답변")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("F&A 삭제 API [DELETE /api/admin/fa]")
+    class deleteFA {
+        private static final String BASE_URL = "/api/admin/fa";
+
+        @Test
+        @DisplayName("F&A 삭제에 성공한다")
+        void success() throws Exception {
+            // given
+            doNothing()
+                    .when(adminStaticService)
+                    .deleteFA(anyLong(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .delete(BASE_URL)
+                    .param("question", questionList.get(0))
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpect(
+                            status().isOk()
+                    )
+                    .andDo(
+                            document(
+                                    "AdminStaticApi/DeleteFA/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestParameters(
+                                            parameterWithName("question").description("삭제할 질문")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    private AddFARequest createAddFARequest() {
+        return new AddFARequest(List.of(new AddFARequest.AddFAKeyValue(questionList.get(0), answerList.get(0)),
+                new AddFARequest.AddFAKeyValue(questionList.get(1), answerList.get(1)),
+                new AddFARequest.AddFAKeyValue(questionList.get(2), answerList.get(2))));
+    }
+}

--- a/src/test/java/umc/stockoneqback/admin/controller/AdminStaticApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/admin/controller/AdminStaticApiControllerTest.java
@@ -19,6 +19,8 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -81,6 +83,9 @@ public class AdminStaticApiControllerTest extends ControllerTest {
                                     "AdminStaticApi/CommonError/Case1",
                                     preprocessRequest(prettyPrint()),
                                     preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
                                     requestParameters(
                                             parameterWithName("question").description("삭제할 질문")
                                     ),
@@ -126,6 +131,9 @@ public class AdminStaticApiControllerTest extends ControllerTest {
                                     "AdminStaticApi/AddFA/Success",
                                     preprocessRequest(prettyPrint()),
                                     preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
                                     requestFields(
                                             fieldWithPath("addFAKeyValueList[].question").description("질문"),
                                             fieldWithPath("addFAKeyValueList[].answer").description("답변")
@@ -164,6 +172,9 @@ public class AdminStaticApiControllerTest extends ControllerTest {
                                     "AdminStaticApi/DeleteFA/Success",
                                     preprocessRequest(prettyPrint()),
                                     preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
                                     requestParameters(
                                             parameterWithName("question").description("삭제할 질문")
                                     )

--- a/src/test/java/umc/stockoneqback/admin/domain/StaticFARedisRepositoryTest.java
+++ b/src/test/java/umc/stockoneqback/admin/domain/StaticFARedisRepositoryTest.java
@@ -1,0 +1,76 @@
+package umc.stockoneqback.admin.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.context.annotation.Import;
+import umc.stockoneqback.common.EmbeddedRedisConfig;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataRedisTest
+@Import(EmbeddedRedisConfig.class)
+@DisplayName("Admin [Repository Layer] -> StaticFARedisRepository 테스트")
+public class StaticFARedisRepositoryTest {
+    @Autowired
+    private StaticFARedisRepository staticFARedisRepository;
+    private final List<String> questionList = Arrays.asList(
+                    "Q1. 슈퍼바이저가 다른 프랜차이즈로 이직할 경우 회원정보는 어떻게 변경하나요?",
+                    "Q2. 알바생이랑 슈퍼바이저는 어떤 기능을 사용할 수 있나요?"
+    );
+    private final List<String> answerList = Arrays.asList(
+                    "A1. 이직하는 프랜차이즈의 발급코드가 필요하기 때문에 탈퇴하고 다시 회원가입을 진행해주셔야 합니다.",
+                    "A2. 알바생은 사장님과 동일하게 Home(재고 관리), Connect, 마이페이지 메뉴를 이용할 수 있고, 슈퍼바이저는 Connect와 마이페이지 메뉴를 이용할 수 있습니다."
+    );
+
+    @BeforeEach
+    void clear(){
+        staticFARedisRepository.deleteAll();
+        for (int i = 0; i < questionList.size(); i++) {
+            staticFARedisRepository.save(StaticFA.builder()
+                            .id(questionList.get(i))
+                            .answer(answerList.get(i))
+                            .build());
+        }
+    }
+
+    @Test
+    @DisplayName("FA 내용이 정상적으로 Redis에 저장되는지 확인한다")
+    void isSaved() {
+        String question = "Q3. 전 개인 카페 자영업자인데 Connect 서비스를 이용하지 못하는 것인가요?";
+        String answer = "A3. 네, 아쉽지만 해당 슈퍼바이저와 연결되는 Connect 서비스를 이용할 수 없습니다. " +
+                "하지만, 재고 관리 기능과 Community 기능을 이용해 카페 운영을 원활하게 할 수 있습니다.";
+        StaticFA staticFA = StaticFA.builder()
+                .id(question)
+                .answer(answer)
+                .build();
+
+        staticFARedisRepository.save(staticFA);
+
+        StaticFA result = staticFARedisRepository.findById(question).orElseThrow();
+        assertAll(
+                () -> assertThat(result.getId()).isEqualTo(question),
+                () -> assertThat(result.getAnswer()).isEqualTo(answer)
+        );
+    }
+
+    @Test
+    @DisplayName("FA 내용이 모두 List로 반환되는지 확인한다")
+    void getFAListOfAll() {
+        List<StaticFA> staticFAList = staticFARedisRepository.findAll();
+
+        assertAll(
+                () -> assertThat(questionList).contains(staticFAList.get(0).getId()),
+                () -> assertThat(answerList).contains(staticFAList.get(0).getAnswer()),
+                () -> assertThat(questionList).contains(staticFAList.get(1).getId()),
+                () -> assertThat(answerList).contains(staticFAList.get(1).getAnswer()),
+                () -> assertThat(staticFAList.size()).isEqualTo(2)
+        );
+    }
+}

--- a/src/test/java/umc/stockoneqback/admin/domain/StaticFARedisRepositoryTest.java
+++ b/src/test/java/umc/stockoneqback/admin/domain/StaticFARedisRepositoryTest.java
@@ -26,11 +26,12 @@ public class StaticFARedisRepositoryTest {
     );
     private final List<String> answerList = Arrays.asList(
                     "A1. 이직하는 프랜차이즈의 발급코드가 필요하기 때문에 탈퇴하고 다시 회원가입을 진행해주셔야 합니다.",
-                    "A2. 알바생은 사장님과 동일하게 Home(재고 관리), Connect, 마이페이지 메뉴를 이용할 수 있고, 슈퍼바이저는 Connect와 마이페이지 메뉴를 이용할 수 있습니다."
+                    "A2. 알바생은 사장님과 동일하게 Home(재고 관리), Connect, 마이페이지 메뉴를 이용할 수 있고, " +
+                            "슈퍼바이저는 Connect와 마이페이지 메뉴를 이용할 수 있습니다."
     );
 
     @BeforeEach
-    void clear(){
+    void setup(){
         staticFARedisRepository.deleteAll();
         for (int i = 0; i < questionList.size(); i++) {
             staticFARedisRepository.save(StaticFA.builder()

--- a/src/test/java/umc/stockoneqback/admin/service/AdminStaticServiceTest.java
+++ b/src/test/java/umc/stockoneqback/admin/service/AdminStaticServiceTest.java
@@ -1,0 +1,110 @@
+package umc.stockoneqback.admin.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import umc.stockoneqback.admin.domain.StaticFA;
+import umc.stockoneqback.admin.dto.request.AddFARequest;
+import umc.stockoneqback.common.EmbeddedRedisConfig;
+import umc.stockoneqback.common.ServiceTest;
+import umc.stockoneqback.fixture.UserFixture;
+import umc.stockoneqback.global.base.BaseException;
+import umc.stockoneqback.global.base.GlobalErrorCode;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Import(EmbeddedRedisConfig.class)
+@DisplayName("Admin [Service Layer] -> AdminStaticService 테스트")
+public class AdminStaticServiceTest extends ServiceTest {
+    @Autowired
+    private AdminStaticService adminStaticService;
+    private final List<String> questionList = Arrays.asList(
+            "Q1. 슈퍼바이저가 다른 프랜차이즈로 이직할 경우 회원정보는 어떻게 변경하나요?",
+            "Q2. 알바생이랑 슈퍼바이저는 어떤 기능을 사용할 수 있나요?"
+    );
+    private final List<String> answerList = Arrays.asList(
+            "A1. 이직하는 프랜차이즈의 발급코드가 필요하기 때문에 탈퇴하고 다시 회원가입을 진행해주셔야 합니다.",
+            "A2. 알바생은 사장님과 동일하게 Home(재고 관리), Connect, 마이페이지 메뉴를 이용할 수 있고, " +
+                    "슈퍼바이저는 Connect와 마이페이지 메뉴를 이용할 수 있습니다."
+    );
+    private static Long ADMIN_ID;
+
+    @BeforeEach
+    void setup(){
+        ADMIN_ID = userRepository.save(UserFixture.ADMIN.toUser()).getId();
+        staticFARedisRepository.deleteAll();
+        for (int i = 0; i < questionList.size(); i++) {
+            staticFARedisRepository.save(StaticFA.builder()
+                    .id(questionList.get(i))
+                    .answer(answerList.get(i))
+                    .build());
+        }
+    }
+
+    @Nested
+    @DisplayName("공통 예외")
+    class commonError {
+        private final String QUESTION = "Q2. 알바생이랑 슈퍼바이저는 어떤 기능을 사용할 수 있나요?";
+
+        @Test
+        @DisplayName("권한이 없는 사용자가 Admin API를 호출한 경우 API 호출에 실패한다")
+        void throwExceptionByUnauthorizedUser() {
+            Long UNAUTHORIZED_ID = userRepository.save(UserFixture.WIZ.toUser()).getId();
+
+            assertThatThrownBy(() -> adminStaticService.deleteFA(UNAUTHORIZED_ID, QUESTION))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(GlobalErrorCode.NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("F&A 추가")
+    class addFA {
+        private final String QUESTION = "Q3. 전 개인 카페 자영업자인데 Connect 서비스를 이용하지 못하는 것인가요?";
+        private final String ANSWER = "A3. 네, 아쉽지만 해당 슈퍼바이저와 연결되는 Connect 서비스를 이용할 수 없습니다. " +
+                "하지만, 재고 관리 기능과 Community 기능을 이용해 카페 운영을 원활하게 할 수 있습니다.";
+
+        @Test
+        @DisplayName("F&A 추가에 성공한다")
+        void success() {
+            AddFARequest addFARequest = new AddFARequest(List.of(new AddFARequest.AddFAKeyValue(QUESTION, ANSWER)));
+            adminStaticService.addFA(ADMIN_ID, addFARequest);
+
+            StaticFA staticFA = staticFARedisRepository.findById(QUESTION).orElseThrow();
+
+            assertAll(
+                    () -> assertThat(staticFA.getId()).isEqualTo(QUESTION),
+                    () -> assertThat(staticFA.getAnswer()).isEqualTo(ANSWER)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("F&A 삭제")
+    class deleteFA {
+        private final String QUESTION = "Q2. 알바생이랑 슈퍼바이저는 어떤 기능을 사용할 수 있나요?";
+        private final String ANSWER = "A2. 알바생은 사장님과 동일하게 Home(재고 관리), Connect, 마이페이지 메뉴를 이용할 수 있고, " +
+                "슈퍼바이저는 Connect와 마이페이지 메뉴를 이용할 수 있습니다.";
+
+        @Test
+        @DisplayName("F&A 삭제에 성공한다")
+        void success() {
+            adminStaticService.deleteFA(ADMIN_ID, QUESTION);
+
+            List<StaticFA> staticFAList = staticFARedisRepository.findAll();
+
+            assertThat(staticFAList).doesNotContain(StaticFA.builder()
+                                                            .id(QUESTION)
+                                                            .answer(ANSWER)
+                                                            .build());
+        }
+    }
+}

--- a/src/test/java/umc/stockoneqback/common/ControllerTest.java
+++ b/src/test/java/umc/stockoneqback/common/ControllerTest.java
@@ -14,6 +14,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
+import umc.stockoneqback.admin.controller.AdminStaticApiController;
+import umc.stockoneqback.admin.service.AdminStaticService;
 import umc.stockoneqback.auth.controller.AuthApiController;
 import umc.stockoneqback.auth.controller.TokenReissueApiController;
 import umc.stockoneqback.auth.service.AuthService;
@@ -76,7 +78,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         BoardListApiController.class,
         UserFindApiController.class,
         FriendProductApiController.class,
-        BusinessProductApiController.class
+        BusinessProductApiController.class,
+        AdminStaticApiController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 @AutoConfigureRestDocs
@@ -173,6 +176,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected UserFAService userFAService;
+
+    @MockBean
+    protected AdminStaticService adminStaticService;
 
     @BeforeEach
     void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {

--- a/src/test/java/umc/stockoneqback/common/ControllerTest.java
+++ b/src/test/java/umc/stockoneqback/common/ControllerTest.java
@@ -51,14 +51,8 @@ import umc.stockoneqback.reply.service.ReplyFindService;
 import umc.stockoneqback.reply.service.ReplyService;
 import umc.stockoneqback.role.service.CompanyService;
 import umc.stockoneqback.role.service.StoreService;
-import umc.stockoneqback.user.controller.UserApiController;
-import umc.stockoneqback.user.controller.UserFindApiController;
-import umc.stockoneqback.user.controller.UserInformationApiController;
-import umc.stockoneqback.user.controller.UserUpdateApiController;
-import umc.stockoneqback.user.service.UserFindService;
-import umc.stockoneqback.user.service.UserInformationService;
-import umc.stockoneqback.user.service.UserService;
-import umc.stockoneqback.user.service.UserUpdateService;
+import umc.stockoneqback.user.controller.*;
+import umc.stockoneqback.user.service.*;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -67,6 +61,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         UserApiController.class,
         UserUpdateApiController.class,
         UserInformationApiController.class,
+        UserFAApiController.class,
         BusinessApiController.class,
         BoardApiController.class,
         BusinessApiController.class,
@@ -175,6 +170,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected ProductOthersService productOthersService;
+
+    @MockBean
+    protected UserFAService userFAService;
 
     @BeforeEach
     void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {

--- a/src/test/java/umc/stockoneqback/common/EmbeddedRedisConfig.java
+++ b/src/test/java/umc/stockoneqback/common/EmbeddedRedisConfig.java
@@ -1,0 +1,99 @@
+package umc.stockoneqback.common;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+@TestConfiguration
+public class EmbeddedRedisConfig {
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    private redis.embedded.RedisServer redisServer;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(host, port);
+        // 패스워드가 있는경우
+        // lettuceConnectionFactory.setPassword("");
+        return lettuceConnectionFactory;
+    }
+
+    @PostConstruct
+    public void redisServer() throws IOException {
+        int port = isRedisRunning() ? findAvailablePort() : this.port;
+        redisServer = new redis.embedded.RedisServer(port);
+        System.out.println("port = " + port);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+
+    /**
+     * Embedded Redis가 현재 실행중인지 확인
+     */
+    private boolean isRedisRunning() throws IOException {
+        return isRunning(executeGrepProcessCommand(port));
+    }
+
+    /**
+     * 현재 PC/서버에서 사용가능한 포트 조회
+     */
+    public int findAvailablePort() throws IOException {
+
+        for (int port = 10000; port <= 65535; port++) {
+            Process process = executeGrepProcessCommand(port);
+            if (!isRunning(process)) {
+                return port;
+            }
+        }
+
+        throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
+    }
+
+    /**
+     * 해당 port를 사용중인 프로세스 확인하는 sh 실행
+     */
+    private Process executeGrepProcessCommand(int port) throws IOException {
+        String command = String.format("netstat -nat | grep LISTEN|grep %d", port);
+        String[] shell = {"/bin/sh", "-c", command};
+        return Runtime.getRuntime().exec(shell);
+    }
+
+    /**
+     * 해당 Process가 현재 실행중인지 확인
+     */
+    private boolean isRunning(Process process) {
+        String line;
+        StringBuilder pidInfo = new StringBuilder();
+
+        try (BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+
+            while ((line = input.readLine()) != null) {
+                pidInfo.append(line);
+            }
+
+        } catch (Exception e) {
+        }
+
+        return !StringUtils.isEmpty(pidInfo.toString());
+    }
+}

--- a/src/test/java/umc/stockoneqback/common/ServiceTest.java
+++ b/src/test/java/umc/stockoneqback/common/ServiceTest.java
@@ -3,7 +3,9 @@ package umc.stockoneqback.common;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
+import umc.stockoneqback.admin.domain.StaticFARedisRepository;
 import umc.stockoneqback.auth.domain.TokenRepository;
 import umc.stockoneqback.board.domain.BoardRepository;
 import umc.stockoneqback.board.domain.like.BoardLikeRepository;
@@ -19,6 +21,7 @@ import umc.stockoneqback.user.domain.UserRepository;
 
 @SpringBootTest
 @Transactional
+@Import(EmbeddedRedisConfig.class)
 public class ServiceTest {
     @Autowired
     private DatabaseCleaner databaseCleaner;
@@ -58,6 +61,9 @@ public class ServiceTest {
 
     @Autowired
     protected BoardLikeRepository boardLikeRepository;
+
+    @Autowired
+    protected StaticFARedisRepository staticFARedisRepository;
 
     public void flushAndClear() {
         databaseCleaner.flushAndClear();

--- a/src/test/java/umc/stockoneqback/fixture/UserFixture.java
+++ b/src/test/java/umc/stockoneqback/fixture/UserFixture.java
@@ -26,7 +26,8 @@ public enum UserFixture {
     OLIVIA("olivia@example.com", "olivia123", "Strong789!", "올리비아", LocalDate.of(1991, 1, 21), "01088889999", Role.SUPERVISOR),
     TONY("tony@example.com", "tony123", "Secure567!", "토니", LocalDate.of(1999, 5, 29), "01044445555", Role.PART_TIMER),
     SOPHIA("sophia@example.com", "sophia123", "NewPass-2023", "소피아", LocalDate.of(1986, 4, 17), "01033334444", Role.MANAGER),
-    UNKNOWN("unknown@hanmail.com", "unknown123", "Pwd78910*", "언노운", LocalDate.of(2000, 10, 31), "01024681398", Role.MANAGER)
+    UNKNOWN("unknown@hanmail.com", "unknown123", "Pwd78910*", "언노운", LocalDate.of(2000, 10, 31), "01024681398", Role.MANAGER),
+    ADMIN("admin@hanmail.com", "admin123", "Admin123!", "관리자", LocalDate.of(2000, 1, 1), "01001234567", Role.ADMINISTRATOR)
     ;
 
     private final String email;

--- a/src/test/java/umc/stockoneqback/user/controller/UserFAApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/user/controller/UserFAApiControllerTest.java
@@ -1,0 +1,109 @@
+package umc.stockoneqback.user.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import umc.stockoneqback.common.ControllerTest;
+import umc.stockoneqback.user.service.dto.response.GetFAResponse;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static umc.stockoneqback.fixture.TokenFixture.ACCESS_TOKEN;
+import static umc.stockoneqback.fixture.TokenFixture.BEARER_TOKEN;
+
+@DisplayName("User [Controller Layer] -> UserFAApiController 테스트")
+public class UserFAApiControllerTest extends ControllerTest {
+    @Nested
+    @DisplayName("사용자 F&A 조회 API [GET /api/user/fa]")
+    class getFAList {
+        private static final String BASE_URL = "/api/user/fa";
+        private final List<String> questionList = Arrays.asList(
+                "Q1. 슈퍼바이저가 다른 프랜차이즈로 이직할 경우 회원정보는 어떻게 변경하나요?",
+                "Q2. 알바생이랑 슈퍼바이저는 어떤 기능을 사용할 수 있나요?",
+                "Q3. 전 개인 카페 자영업자인데 Connect 서비스를 이용하지 못하는 것인가요?"
+        );
+        private final List<String> answerList = Arrays.asList(
+                "A1. 이직하는 프랜차이즈의 발급코드가 필요하기 때문에 탈퇴하고 다시 회원가입을 진행해주셔야 합니다.",
+                "A2. 알바생은 사장님과 동일하게 Home(재고 관리), Connect, 마이페이지 메뉴를 이용할 수 있고, " +
+                        "슈퍼바이저는 Connect와 마이페이지 메뉴를 이용할 수 있습니다.",
+                "A3. 네, 아쉽지만 해당 슈퍼바이저와 연결되는 Connect 서비스를 이용할 수 없습니다. " +
+                        "하지만, 재고 관리 기능과 Community 기능을 이용해 카페 운영을 원활하게 할 수 있습니다."
+        );
+
+        @Test
+        @DisplayName("사용자 F&A 조회에 성공한다")
+        void success() throws Exception {
+            // given
+            doReturn(getFAResponse())
+                    .when(userFAService)
+                    .getFA();
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .header(AUTHORIZATION, BEARER_TOKEN + " " + ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result[0]").exists(),
+                            jsonPath("$.result[0].question").value(questionList.get(0)),
+                            jsonPath("$.result[0].answer").value(answerList.get(0)),
+                            jsonPath("$.result[1]").exists(),
+                            jsonPath("$.result[1].question").value(questionList.get(1)),
+                            jsonPath("$.result[1].answer").value(answerList.get(1)),
+                            jsonPath("$.result[2]").exists(),
+                            jsonPath("$.result[2].question").value(questionList.get(2)),
+                            jsonPath("$.result[2].answer").value(answerList.get(2)),
+                            jsonPath("$.result[3]").doesNotExist()
+                            )
+                    .andDo(
+                            document(
+                                    "UserFAApi/GetFAList/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").type(JsonFieldType.STRING).description("커스텀 예외 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지"),
+                                            fieldWithPath("result[].question").type(JsonFieldType.STRING).description("질문"),
+                                            fieldWithPath("result[].answer").type(JsonFieldType.STRING).description("답변")
+                                    )
+                            )
+                    );
+        }
+
+        private List<GetFAResponse> getFAResponse() {
+            List<GetFAResponse> getFAResponseList = new ArrayList<>();
+            getFAResponseList.add(new GetFAResponse("Q1. 슈퍼바이저가 다른 프랜차이즈로 이직할 경우 회원정보는 어떻게 변경하나요?",
+                    "A1. 이직하는 프랜차이즈의 발급코드가 필요하기 때문에 탈퇴하고 다시 회원가입을 진행해주셔야 합니다."));
+            getFAResponseList.add(new GetFAResponse("Q2. 알바생이랑 슈퍼바이저는 어떤 기능을 사용할 수 있나요?",
+                    "A2. 알바생은 사장님과 동일하게 Home(재고 관리), Connect, 마이페이지 메뉴를 이용할 수 있고, " +
+                            "슈퍼바이저는 Connect와 마이페이지 메뉴를 이용할 수 있습니다."));
+            getFAResponseList.add(new GetFAResponse("Q3. 전 개인 카페 자영업자인데 Connect 서비스를 이용하지 못하는 것인가요?",
+                    "A3. 네, 아쉽지만 해당 슈퍼바이저와 연결되는 Connect 서비스를 이용할 수 없습니다. " +
+                            "하지만, 재고 관리 기능과 Community 기능을 이용해 카페 운영을 원활하게 할 수 있습니다."));
+            return getFAResponseList;
+        }
+    }
+}

--- a/src/test/java/umc/stockoneqback/user/service/UserFAServiceTest.java
+++ b/src/test/java/umc/stockoneqback/user/service/UserFAServiceTest.java
@@ -1,0 +1,68 @@
+package umc.stockoneqback.user.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import umc.stockoneqback.admin.domain.StaticFA;
+import umc.stockoneqback.common.EmbeddedRedisConfig;
+import umc.stockoneqback.common.ServiceTest;
+import umc.stockoneqback.user.service.dto.response.GetFAResponse;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Import(EmbeddedRedisConfig.class)
+@DisplayName("User [Service Layer] -> UserFAService 테스트")
+public class UserFAServiceTest extends ServiceTest {
+    @Autowired
+    private UserFAService userFAService;
+    private final List<String> questionList = Arrays.asList(
+            "Q1. 슈퍼바이저가 다른 프랜차이즈로 이직할 경우 회원정보는 어떻게 변경하나요?",
+            "Q2. 알바생이랑 슈퍼바이저는 어떤 기능을 사용할 수 있나요?",
+            "Q3. 전 개인 카페 자영업자인데 Connect 서비스를 이용하지 못하는 것인가요?"
+    );
+    private final List<String> answerList = Arrays.asList(
+            "A1. 이직하는 프랜차이즈의 발급코드가 필요하기 때문에 탈퇴하고 다시 회원가입을 진행해주셔야 합니다.",
+            "A2. 알바생은 사장님과 동일하게 Home(재고 관리), Connect, 마이페이지 메뉴를 이용할 수 있고, " +
+                    "슈퍼바이저는 Connect와 마이페이지 메뉴를 이용할 수 있습니다.",
+            "A3. 네, 아쉽지만 해당 슈퍼바이저와 연결되는 Connect 서비스를 이용할 수 없습니다. " +
+                    "하지만, 재고 관리 기능과 Community 기능을 이용해 카페 운영을 원활하게 할 수 있습니다."
+    );
+
+    @BeforeEach
+    void setup(){
+        staticFARedisRepository.deleteAll();
+        for (int i = 0; i < questionList.size(); i++) {
+            staticFARedisRepository.save(StaticFA.builder()
+                    .id(questionList.get(i))
+                    .answer(answerList.get(i))
+                    .build());
+        }
+    }
+
+    @Nested
+    @DisplayName("F&A 게시판 조회")
+    class getFAList {
+        @Test
+        @DisplayName("F&A 게시판 조회에 성공한다")
+        void success() {
+            List<GetFAResponse> getFAResponseList = userFAService.getFA();
+
+            assertAll(
+                    () -> assertThat(questionList).contains(getFAResponseList.get(0).question()),
+                    () -> assertThat(answerList).contains(getFAResponseList.get(0).answer()),
+                    () -> assertThat(questionList).contains(getFAResponseList.get(1).question()),
+                    () -> assertThat(answerList).contains(getFAResponseList.get(1).answer()),
+                    () -> assertThat(questionList).contains(getFAResponseList.get(2).question()),
+                    () -> assertThat(answerList).contains(getFAResponseList.get(2).answer()),
+                    () -> assertThat(getFAResponseList.size()).isEqualTo(3)
+            );
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -22,6 +22,15 @@ spring:
     import:
       - classpath:secret.yml
 
+  redis:
+    lettuce:
+      pool:
+        min-idle: 0
+        max-idle: 8
+        max-active: 8
+    port: 16379
+    host: localhost
+
 logging:
   level:
     com:


### PR DESCRIPTION
## Summary 📌
- F&A 게시판 조회 API를 구현한다
## Describe your changes 📝
- 일반 사용자는 F&A 게시판 조회할 수 있는 정적인 데이터 제공
  - 정적인 데이터의 빠른 제공을 위해 Redis 사용
- 관리자는 F&A 질문-답변을 추가, 삭제할 수 있는 API 추가
  - 관리자 권한 추가
## Check list ✅
- [X] I write PR according to the form
- [X] All tests are passed
- [X] Program works normally
- [X] I set proper PR labels
- [X] I remove any redundant codes

## Opinions 🗣️
- Redis 관련
  - 로컬에서 해당 API의 동작을 확인하기 위해서는 Redis 설치 및 실행이 되어있는 상태여야 합니다🥲
  - 테스트코드는 Embedded Redis를 사용하기 때문에 별다른 설정 없이 통과되실 거에요!
  - **후에 AWS 연결하여 배포할 때 AWS 서버에 Redis 설치를 해야 합니다(TODO)**
- 관리자 권한은 당장 기능 개발에 있었던 요소는 아니지만, 기능명세서의 설명 상 정적인 페이지에 대해 관리 권한을 가지는 유저가 별도로 존재하는 로직이 필요할 것으로 보여서 관리자의 추가, 삭제에 대한 API를 추가하게 되었습니다😅

## Issue numbers and link 🚪
Closes #99 
