### PR TITLE
[Fix] 제품 수정 로직에서 같은 이미지의 중복 업로드를 방지하도록 로직 수정

### DIFF
--- a/src/main/java/umc/stockoneqback/product/service/ProductService.java
+++ b/src/main/java/umc/stockoneqback/product/service/ProductService.java
@@ -103,7 +103,7 @@ public class ProductService {
     public void editProduct(Long userId, Long productId, Product newProduct, MultipartFile image) {
         Product product = findProductById(productId);
         checkRequestIdHasRequestProduct(userId, product);
-        String imageUrl = null;
+        String imageUrl = product.getImageUrl();
         if (image != null)
             imageUrl = fileService.uploadProductFiles(image);
         product.update(newProduct, imageUrl);


### PR DESCRIPTION
## Summary 📌
- 제품 수정 로직에서 같은 이미지의 중복 업로드를 방지하도록 로직 수정
## Describe your changes 📝
- 제품 수정 서비스 로직에서 imageUrl을 null 대신 기존 제품의 imageUrl로 초기화
## Check list ✅
- [X] I write PR according to the form
- [X] All tests are passed
- [X] Program works normally
- [X] I set proper PR labels
- [X] I remove any redundant codes

## Opinions 🗣️
- 한 줄 변경되었습니다..!
## Issue numbers and link 🚪
Closes #115 
