### PR TITLE
[Fix] 사장님 회원가입시 User와 Store가 DB에 저장되는 순서를 바꾼다

### DIFF
--- a/src/main/java/umc/stockoneqback/business/service/BusinessProductService.java
+++ b/src/main/java/umc/stockoneqback/business/service/BusinessProductService.java
@@ -54,7 +54,7 @@ public class BusinessProductService {
         return productOthersService.getListOfSearchProductOthers(managerStore, storeConditionValue, searchConditionValue, productId);
     }
 
-    public User checkRelation(User supervisor, Long managerId) {
+    private User checkRelation(User supervisor, Long managerId) {
         User manager = userFindService.findById(managerId);
         businessService.validateNotExist(supervisor, manager);
 

--- a/src/main/java/umc/stockoneqback/product/domain/ProductRepository.java
+++ b/src/main/java/umc/stockoneqback/product/domain/ProductRepository.java
@@ -15,8 +15,8 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
     @Query(value = "SELECT p.* FROM product p WHERE p.status = '정상' AND p.store = :store " +
             "AND p.store_condition = :storeCondition AND p.name = :name", nativeQuery = true)
     Optional<Product> isExistProductByName(@Param("store") Store store,
-                                 @Param("storeCondition") String storeCondition,
-                                 @Param("name") String productName);
+                                           @Param("storeCondition") String storeCondition,
+                                           @Param("name") String productName);
 
     @Query(value = "SELECT p.* FROM product p WHERE p.id = :id AND p.status = '정상'", nativeQuery = true)
     Optional<Product> findProductById(@Param("id") Long productId);
@@ -25,17 +25,20 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
             "AND p.store_condition = :storeCondition AND p.status = '정상'", nativeQuery = true)
     Integer countProductAll(@Param("store") Store store,
                             @Param("storeCondition") String storeCondition);
+
     @Query(value = "SELECT count(*) FROM product p WHERE p.store = :store AND p.store_condition = :storeCondition " +
             "AND p.expiration_date < :currentDate AND p.status = '정상'", nativeQuery = true)
     Integer countProductPass(@Param("store") Store store,
                              @Param("storeCondition") String storeCondition,
                              @Param("currentDate") LocalDate currentDate);
+
     @Query(value = "SELECT count(*) FROM product p WHERE p.store = :store AND p.store_condition = :storeCondition " +
             "AND (p.expiration_date >= :currentDate AND p.expiration_date <= :standardDate) AND p.status = '정상'", nativeQuery = true)
     Integer countProductClose(@Param("store") Store store,
                               @Param("storeCondition") String storeCondition,
                               @Param("currentDate") LocalDate currentDate,
                               @Param("standardDate") LocalDate standardDate);
+
     @Query(value = "SELECT count(*) FROM product p WHERE p.store = :store AND p.store_condition = :storeCondition " +
             "AND p.require_quant >= p.stock_quant AND p.status = '정상'", nativeQuery = true)
     Integer countProductLack(@Param("store") Store store,
@@ -44,12 +47,10 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
     @Query(value = "SELECT p.* FROM product p WHERE p.status = '정상' AND p.expiration_date < :currentDate AND " +
             "p.store = (SELECT s.id FROM store s WHERE s.manager_id = :manager) ORDER BY p.name", nativeQuery = true)
     List<Product> findPassByManager(@Param("manager") User user,
-                                   @Param("currentDate") LocalDate currentDate);
+                                    @Param("currentDate") LocalDate currentDate);
 
     @Query(value = "SELECT p.* FROM product p WHERE p.status = '정상' AND p.expiration_date < :currentDate AND " +
             "p.store = (SELECT t.store_id FROM part_timer t WHERE t.part_timer_id = :partTimer) ORDER BY p.name", nativeQuery = true)
     List<Product> findPassByPartTimer(@Param("partTimer") User user,
-                                     @Param("currentDate") LocalDate currentDate);
+                                      @Param("currentDate") LocalDate currentDate);
 }
-
-

--- a/src/main/java/umc/stockoneqback/role/domain/store/Store.java
+++ b/src/main/java/umc/stockoneqback/role/domain/store/Store.java
@@ -38,18 +38,18 @@ public class Store extends BaseTimeEntity {
     private Status status;
 
     @Builder
-    public Store(String name, String sector, String code, String address) {
+    public Store(String name, String sector, String code, String address, User manager) {
         this.name = name;
         this.sector = sector;
         this.code = code;
         this.address = address;
-        this.manager = null;
+        this.manager = manager;
         this.partTimers = PartTimers.createPartTimers();
         this.status = NORMAL;
     }
 
-    public static Store createStore(String name, String sector, String address) {
-        return new Store(name, sector, generateRandomCode(), address);
+    public static Store createStore(String name, String sector, String address, User manager) {
+        return new Store(name, sector, generateRandomCode(), address, manager);
     }
 
     public void updateManager(User manager) {

--- a/src/main/java/umc/stockoneqback/role/domain/store/StoreRepository.java
+++ b/src/main/java/umc/stockoneqback/role/domain/store/StoreRepository.java
@@ -1,11 +1,20 @@
 package umc.stockoneqback.role.domain.store;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.stockoneqback.user.domain.User;
 
 import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
+    // @Query
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(value = "UPDATE store SET manager_id = :managerId WHERE id = :storeId", nativeQuery = true)
+    void updateManagerIdById(@Param("storeId") Long storeId, @Param("managerId") Long managerId);
+
+    // Query Method
     boolean existsByName(String name);
     Optional<Store> findByName(String name);
     Optional<Store> findByManager(User user);

--- a/src/main/java/umc/stockoneqback/role/service/StoreService.java
+++ b/src/main/java/umc/stockoneqback/role/service/StoreService.java
@@ -9,17 +9,21 @@ import umc.stockoneqback.role.domain.store.Store;
 import umc.stockoneqback.role.domain.store.StoreRepository;
 import umc.stockoneqback.role.exception.StoreErrorCode;
 import umc.stockoneqback.user.domain.User;
+import umc.stockoneqback.user.service.UserFindService;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class StoreService {
     private final StoreRepository storeRepository;
+    private final UserFindService userFindService;
 
     @Transactional
-    public Long save(String name, String sector, String address) {
+    public Long save(String name, String sector, String address, Long managerId) {
         validateAlreadyExistStore(name);
-        Store store = Store.createStore(name, sector, address);
+
+        User manager = userFindService.findById(managerId);
+        Store store = Store.createStore(name, sector, address, manager);
 
         return storeRepository.save(store).getId();
     }

--- a/src/main/java/umc/stockoneqback/user/controller/UserApiController.java
+++ b/src/main/java/umc/stockoneqback/user/controller/UserApiController.java
@@ -22,8 +22,8 @@ public class UserApiController {
 
     @PostMapping("/sign-up/manager")
     public ResponseEntity<Void> signUpManager(@RequestBody @Valid SignUpManagerRequest request) {
-        Long savedStoreId = storeService.save(request.storeName(), request.storeSector(), request.storeAddress());
-        Long savedUserId = userService.saveManager(request.toUser(), savedStoreId);
+        Long savedUserId = userService.saveManager(request.toUser());
+        Long savedStoreId = storeService.save(request.storeName(), request.storeSector(), request.storeAddress(), savedUserId);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/umc/stockoneqback/user/domain/UserRepository.java
+++ b/src/main/java/umc/stockoneqback/user/domain/UserRepository.java
@@ -26,6 +26,11 @@ public interface UserRepository extends JpaRepository<User, Long>, UserFindQuery
     @Query(value = "UPDATE users SET modified_date = :modifiedDate WHERE id = :userId", nativeQuery = true)
     void updateModifiedDateById(@Param("userId") Long userId, @Param("modifiedDate") LocalDate modifiedDate);
 
+    @Transactional
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(value = "UPDATE users SET manager_store_id = :storeId WHERE id = :userId", nativeQuery = true)
+    void updateManagerStoreIdById(@Param("userId") Long userId, @Param("storeId") Long storeId);
+
     // Query Method
     boolean existsByLoginIdAndStatus(String loginId, Status status);
     boolean existsByEmailAndStatus(Email email, Status status);

--- a/src/main/java/umc/stockoneqback/user/service/UserService.java
+++ b/src/main/java/umc/stockoneqback/user/service/UserService.java
@@ -47,13 +47,10 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional
-    public Long saveManager(User user, Long storeId) {
+    public Long saveManager(User user) {
         validateDuplicate(user.getLoginId(), user.getEmail());
 
-        Store store = storeService.findById(storeId);
         userRepository.save(user);
-        store.updateManager(user);
-
         return user.getId();
     }
 

--- a/src/test/java/umc/stockoneqback/admin/controller/AdminStaticApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/admin/controller/AdminStaticApiControllerTest.java
@@ -185,8 +185,11 @@ public class AdminStaticApiControllerTest extends ControllerTest {
     }
 
     private AddFARequest createAddFARequest() {
-        return new AddFARequest(List.of(new AddFARequest.AddFAKeyValue(questionList.get(0), answerList.get(0)),
-                new AddFARequest.AddFAKeyValue(questionList.get(1), answerList.get(1)),
-                new AddFARequest.AddFAKeyValue(questionList.get(2), answerList.get(2))));
+        return new AddFARequest(
+                List.of(new AddFARequest.AddFAKeyValue(questionList.get(0), answerList.get(0)),
+                        new AddFARequest.AddFAKeyValue(questionList.get(1), answerList.get(1)),
+                        new AddFARequest.AddFAKeyValue(questionList.get(2), answerList.get(2))
+                )
+        );
     }
 }

--- a/src/test/java/umc/stockoneqback/auth/domain/FcmTokenRedisRepositoryTest.java
+++ b/src/test/java/umc/stockoneqback/auth/domain/FcmTokenRedisRepositoryTest.java
@@ -22,7 +22,7 @@ public class FcmTokenRedisRepositoryTest {
     @Autowired
     private FcmTokenRedisRepository fcmTokenRedisRepository;
 
-    final Long USER_ID = 1L;
+    private final Long USER_ID = 1L;
 
     @BeforeEach
     void setup() {

--- a/src/test/java/umc/stockoneqback/auth/domain/TokenRepositoryTest.java
+++ b/src/test/java/umc/stockoneqback/auth/domain/TokenRepositoryTest.java
@@ -16,8 +16,8 @@ class TokenRepositoryTest extends RepositoryTest {
     @Autowired
     private TokenRepository tokenRepository;
 
-    final Long USER_ID = 1L;
-    final String REFRESH_TOKEN = "example_refresh_token";
+    private final Long USER_ID = 1L;
+    private final String REFRESH_TOKEN = "example_refresh_token";
 
     @BeforeEach
     void setup() {

--- a/src/test/java/umc/stockoneqback/auth/service/AuthServiceTest.java
+++ b/src/test/java/umc/stockoneqback/auth/service/AuthServiceTest.java
@@ -26,7 +26,7 @@ class AuthServiceTest extends ServiceTest {
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
-    final Long USER_ID = 1L;
+    private final Long USER_ID = 1L;
 
     @Nested
     @DisplayName("로그인")

--- a/src/test/java/umc/stockoneqback/auth/service/TokenReissueServiceTest.java
+++ b/src/test/java/umc/stockoneqback/auth/service/TokenReissueServiceTest.java
@@ -26,11 +26,11 @@ class TokenReissueServiceTest extends ServiceTest {
     private JwtTokenProvider jwtTokenProvider;
 
     private final Long USER_ID = 1L;
-    private String REFRESH_TOKEN;
+    private String refreshToken;
 
     @BeforeEach
     void setup() {
-        REFRESH_TOKEN = jwtTokenProvider.createRefreshToken(USER_ID);
+        refreshToken = jwtTokenProvider.createRefreshToken(USER_ID);
     }
 
     @Nested
@@ -40,7 +40,7 @@ class TokenReissueServiceTest extends ServiceTest {
         @DisplayName("RefreshToken이 유효하지 않으면 예외가 발생한다")
         void throwExceptionByAuthInvalidToken() {
             // when - then
-            assertThatThrownBy(() -> tokenReissueService.reissueTokens(USER_ID, REFRESH_TOKEN, FCM_TOKEN))
+            assertThatThrownBy(() -> tokenReissueService.reissueTokens(USER_ID, refreshToken, FCM_TOKEN))
                     .isInstanceOf(BaseException.class)
                     .hasMessage(AuthErrorCode.AUTH_INVALID_TOKEN.getMessage());
         }
@@ -49,10 +49,10 @@ class TokenReissueServiceTest extends ServiceTest {
         @DisplayName("RefreshToken을 통해서 AccessToken과 RefreshToken을 재발급받는데 성공한다")
         void success() {
             // given
-            tokenRepository.save(Token.createToken(USER_ID, REFRESH_TOKEN));
+            tokenRepository.save(Token.createToken(USER_ID, refreshToken));
 
             // when
-            TokenResponse response = tokenReissueService.reissueTokens(USER_ID, REFRESH_TOKEN, FCM_TOKEN);
+            TokenResponse response = tokenReissueService.reissueTokens(USER_ID, refreshToken, FCM_TOKEN);
 
             // then
             assertAll(

--- a/src/test/java/umc/stockoneqback/auth/service/TokenServiceTest.java
+++ b/src/test/java/umc/stockoneqback/auth/service/TokenServiceTest.java
@@ -20,8 +20,8 @@ class TokenServiceTest extends ServiceTest {
     @Autowired
     private TokenService tokenService;
 
-    final Long USER_ID = 1L;
-    final String REFRESH_TOKEN = "example_refresh_token";
+    private final Long USER_ID = 1L;
+    private final String REFRESH_TOKEN = "example_refresh_token";
 
     @Nested
     @DisplayName("Refresh Token 발급 혹은 재발급")

--- a/src/test/java/umc/stockoneqback/auth/service/TokenServiceTest.java
+++ b/src/test/java/umc/stockoneqback/auth/service/TokenServiceTest.java
@@ -134,7 +134,7 @@ class TokenServiceTest extends ServiceTest {
     void findAllOnlineUsers() {
         // given
         final Long SECOND_USER_ID = 2L;
-        final String SECOND_USER_FCM_TOKEN = "secondexampleFcmToken";
+        final String SECOND_USER_FCM_TOKEN = "example_refresh_token_2";
         fcmTokenRedisRepository.save(FcmToken.createFcmToken(USER_ID, FCM_TOKEN));
         fcmTokenRedisRepository.save(FcmToken.createFcmToken(SECOND_USER_ID, SECOND_USER_FCM_TOKEN));
 

--- a/src/test/java/umc/stockoneqback/board/controller/BoardListApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/board/controller/BoardListApiControllerTest.java
@@ -42,6 +42,7 @@ class BoardListApiControllerTest extends ControllerTest {
     private static final String SORT_BY_TIME = "최신순";
     private static final String SEARCH_TYPE = "제목";
     private static final String SEARCH_WORD = "제목";
+
     @Nested
     @DisplayName("게시글 목록 조회 API [GET /api/boards]")
     class getBoardList {

--- a/src/test/java/umc/stockoneqback/board/domain/BoardTest.java
+++ b/src/test/java/umc/stockoneqback/board/domain/BoardTest.java
@@ -15,7 +15,7 @@ import static umc.stockoneqback.global.base.Status.NORMAL;
 
 @DisplayName("Board 도메인 테스트")
 public class BoardTest {
-    private User[] writer = new User[2];
+    private final User[] writer = new User[2];
     private Board board;
 
     @BeforeEach
@@ -40,10 +40,10 @@ public class BoardTest {
     @Test
     @DisplayName("Board에 Comment를 추가한다")
     void addComment() {
-        for(int i = 1; i <= 2; i++) {
+        for (int i = 1; i <= 2; i++) {
             board.addComment(writer[0], "이미지" + i, "댓글" + i);
         }
-        for(int i = 3; i <= 5; i++){
+        for (int i = 3; i <= 5; i++) {
             board.addComment(writer[1], "이미지" + i, "댓글" + i);
         }
 

--- a/src/test/java/umc/stockoneqback/board/domain/like/BoardLikeTest.java
+++ b/src/test/java/umc/stockoneqback/board/domain/like/BoardLikeTest.java
@@ -12,12 +12,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("BoardLike 도메인 테스트")
 public class BoardLikeTest {
-    private static final User user = UserFixture.SAEWOO.toUser();
-    private static final Board board = BoardFixture.BOARD_0.toBoard(user);
-
     @Test
     @DisplayName("BoardLike를 생성한다")
     void registerFollow() {
+        User user = UserFixture.SAEWOO.toUser();
+        Board board = BoardFixture.BOARD_0.toBoard(user);
+
         BoardLike boardLike = BoardLike.registerBoardLike(user, board);
         Assertions.assertAll(
                 () -> assertThat(boardLike.getUser()).isEqualTo(user),

--- a/src/test/java/umc/stockoneqback/board/infra/query/BoardListQueryRepositoryImplTest.java
+++ b/src/test/java/umc/stockoneqback/board/infra/query/BoardListQueryRepositoryImplTest.java
@@ -26,6 +26,7 @@ class BoardListQueryRepositoryImplTest extends RepositoryTest {
 
     private final Board[] boardList = new Board[10];
     private User writer;
+
     private static final BoardSearchType SEARCH_TYPE = BoardSearchType.TITLE;
     private static final String SEARCH_TITLE = "제목";
     private static final String SEARCH_CONTENT = "5";

--- a/src/test/java/umc/stockoneqback/board/service/BoardListServiceTest.java
+++ b/src/test/java/umc/stockoneqback/board/service/BoardListServiceTest.java
@@ -28,11 +28,13 @@ class BoardListServiceTest extends ServiceTest {
     @Autowired
     private BoardFindService boardFindService;
 
-    private final Board[] boardList = new Board[10];
-    private final List<Long> selectedBoardId = new ArrayList<>();
     private User writer;
     private User not_writer;
     private Long userId;
+
+    private final Board[] boardList = new Board[10];
+    private final List<Long> selectedBoardId = new ArrayList<>();
+
     private static final int PAGE = 0;
     private static final String SORT_BY = "조회순";
     private static final String INVALID_SORT = "댓글순";
@@ -92,7 +94,7 @@ class BoardListServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("정렬 기준과 검색에 따른 게시글 목록 조회에 성공한다")
-        void getBoardListByHit() throws IOException {
+        void getBoardListByHit() {
             // when
             CustomBoardListResponse<BoardList> boardListResponse = boardListService.getBoardList(userId, PAGE, SORT_BY, SEARCH_TYPE, SEARCH_WORD);
 
@@ -144,7 +146,7 @@ class BoardListServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("정렬 기준과 검색에 따른 게시글 목록 조회에 성공한다")
-        void getMyBoardList() throws IOException {
+        void getMyBoardList() {
             // when
             CustomBoardListResponse<BoardList> myBoardList = boardListService.getMyBoardList(userId, PAGE, SORT_BY, SEARCH_TYPE, SEARCH_WORD);
 

--- a/src/test/java/umc/stockoneqback/board/service/BoardServiceTest.java
+++ b/src/test/java/umc/stockoneqback/board/service/BoardServiceTest.java
@@ -31,7 +31,9 @@ public class BoardServiceTest extends ServiceTest {
 
     private User writer;
     private User not_writer;
+
     private Board board;
+
     private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     @BeforeEach

--- a/src/test/java/umc/stockoneqback/board/service/like/BoardLikeServiceTest.java
+++ b/src/test/java/umc/stockoneqback/board/service/like/BoardLikeServiceTest.java
@@ -26,12 +26,14 @@ public class BoardLikeServiceTest extends ServiceTest {
 
     private User user1;
     private User user2;
+
     private Board board;
 
     @BeforeEach
     void setup() {
         user1 = userRepository.save(SAEWOO.toUser());
         user2 = userRepository.save(ANNE.toUser());
+
         board = boardRepository.save(BOARD_0.toBoard(user1));
     }
 

--- a/src/test/java/umc/stockoneqback/business/service/BusinessProductServiceTest.java
+++ b/src/test/java/umc/stockoneqback/business/service/BusinessProductServiceTest.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import umc.stockoneqback.business.domain.Business;
 import umc.stockoneqback.common.ServiceTest;
 import umc.stockoneqback.fixture.ProductFixture;
-import umc.stockoneqback.fixture.StoreFixture;
 import umc.stockoneqback.product.domain.StoreCondition;
 import umc.stockoneqback.product.service.dto.response.GetTotalProductResponse;
 import umc.stockoneqback.product.service.dto.response.SearchProductOthersResponse;
@@ -21,9 +20,9 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static umc.stockoneqback.fixture.StoreFixture.D_PIZZA;
 import static umc.stockoneqback.fixture.StoreFixture.Z_SIHEUNG;
-import static umc.stockoneqback.fixture.UserFixture.*;
+import static umc.stockoneqback.fixture.UserFixture.ELLA;
+import static umc.stockoneqback.fixture.UserFixture.JACK;
 
 @DisplayName("Business [Service Layer] -> BusinessProductService 테스트")
 public class BusinessProductServiceTest extends ServiceTest {

--- a/src/test/java/umc/stockoneqback/business/service/BusinessProductServiceTest.java
+++ b/src/test/java/umc/stockoneqback/business/service/BusinessProductServiceTest.java
@@ -5,28 +5,24 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import umc.stockoneqback.auth.service.AuthService;
 import umc.stockoneqback.business.domain.Business;
-import umc.stockoneqback.business.exception.BusinessErrorCode;
 import umc.stockoneqback.common.ServiceTest;
 import umc.stockoneqback.fixture.ProductFixture;
-import umc.stockoneqback.global.base.Status;
-import umc.stockoneqback.global.exception.BaseException;
-import umc.stockoneqback.product.domain.Product;
+import umc.stockoneqback.fixture.StoreFixture;
+import umc.stockoneqback.product.domain.StoreCondition;
 import umc.stockoneqback.product.service.dto.response.GetTotalProductResponse;
 import umc.stockoneqback.product.service.dto.response.SearchProductOthersResponse;
 import umc.stockoneqback.role.domain.company.Company;
 import umc.stockoneqback.role.domain.store.Store;
 import umc.stockoneqback.user.domain.User;
-import umc.stockoneqback.user.service.UserService;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static umc.stockoneqback.fixture.StoreFixture.Z_YEONGTONG;
+import static umc.stockoneqback.fixture.StoreFixture.D_PIZZA;
+import static umc.stockoneqback.fixture.StoreFixture.Z_SIHEUNG;
 import static umc.stockoneqback.fixture.UserFixture.*;
 
 @DisplayName("Business [Service Layer] -> BusinessProductService 테스트")
@@ -34,106 +30,69 @@ public class BusinessProductServiceTest extends ServiceTest {
     @Autowired
     private BusinessProductService businessProductService;
 
-    @Autowired
-    private UserService userService;
-
-    @Autowired
-    private AuthService authService;
-
     private final ProductFixture[] productFixtures = ProductFixture.values();
-    private final Product[] products = new Product[17];
-    private static Long MANAGER_ID;
-    private static Store zStore;
-    private static Long USER_ID;
-    private static Company company;
+
+    private static User manager;
+    private static User supervisor;
+    private static Store store;
 
     @BeforeEach
     void setup() {
-        zStore = storeRepository.save(Z_YEONGTONG.toStore());
-        MANAGER_ID = userService.saveManager(ANNE.toUser(), zStore.getId());
-        for (int i = 0; i < products.length-1; i++)
-            products[i] = productRepository.save(productFixtures[i].toProduct(zStore));
+        manager = userRepository.save(ELLA.toUser());
+        store = storeRepository.save(Store.createStore(Z_SIHEUNG.getName(), Z_SIHEUNG.getSector(), Z_SIHEUNG.getAddress(), manager));
 
-        company = companyRepository.save(Company.builder()
-                .name("A회사")
-                .sector("카페")
-                .code("RANDOM")
-                .build());
-        USER_ID = userService.saveSupervisor(WIZ.toUser(), company.getName(), company.getCode());
-        authService.login(WIZ.getLoginId(), WIZ.getPassword());
+        companyRepository.save(new Company("A 납품업체", "과일", "ABC123"));
+        supervisor = userRepository.save(JACK.toUser());
+        businessRepository.save(new Business(manager, supervisor));
 
-        User user = userRepository.findById(USER_ID).orElseThrow();
-        User manager = userRepository.findById(MANAGER_ID).orElseThrow();
-        businessRepository.save(Business.builder()
-                .manager(manager)
-                .supervisor(user)
-                .build());
-    }
-
-    @Nested
-    @DisplayName("공통 예외")
-    class commonError {
-        @Test
-        @DisplayName("요청하는 사용자와 요청 대상이 비즈니스 관계가 아닐 경우 API 호출에 실패한다")
-        void throwExceptionByInvalidFriend() {
-            User user = userRepository.save(UNKNOWN.toUser());
-            User manager = userRepository.findByLoginIdAndStatus(ANNE.toUser().getLoginId(), Status.NORMAL).orElseThrow();
-
-            assertThatThrownBy(() -> businessProductService.checkRelation(user, manager.getId()))
-                    .isInstanceOf(BaseException.class)
-                    .hasMessage(BusinessErrorCode.BUSINESS_NOT_FOUND.getMessage());
-        }
+        for (int i = 0; i < productFixtures.length; i++)
+            productRepository.save(productFixtures[i].toProduct(store));
     }
 
     @Nested
     @DisplayName("사장님 가게의 제품명 검색")
-    class findProductOthers {
+    class searchProductOthers {
         @Test
         @DisplayName("사장님 가게의 제품명 검색에 성공한다")
         void success() throws IOException {
-            User user = userRepository.findByLoginIdAndStatus(WIZ.toUser().getLoginId(), Status.NORMAL).orElseThrow();
-            User manager = userRepository.findByLoginIdAndStatus(ANNE.toUser().getLoginId(), Status.NORMAL).orElseThrow();
-
-            List<SearchProductOthersResponse> searchProductOthersResponseList =
-                    businessProductService.searchProductOthers(user.getId(), manager.getId(),
-                            products[0].getStoreCondition().getValue(), products[0].getName());
+            // when - then
+            List<SearchProductOthersResponse> searchProductOthersResponseList = businessProductService.searchProductOthers(
+                    supervisor.getId(), manager.getId(), StoreCondition.ROOM.getValue(), productFixtures[0].getName());
 
             assertAll(
-                    () -> assertThat(searchProductOthersResponseList.get(0).id()).isEqualTo(products[0].getId()),
-                    () -> assertThat(searchProductOthersResponseList.get(0).name()).isEqualTo(products[0].getName()),
-                    () -> assertThat(searchProductOthersResponseList.get(0).stockQuantity()).isEqualTo(products[0].getStockQuant())
+                    () -> assertThat(searchProductOthersResponseList.get(0).id()).isEqualTo(1L),
+                    () -> assertThat(searchProductOthersResponseList.get(0).name()).isEqualTo(productFixtures[0].getName()),
+                    () -> assertThat(searchProductOthersResponseList.get(0).stockQuantity()).isEqualTo(productFixtures[0].getStockQuantity())
             );
         }
     }
 
     @Nested
     @DisplayName("사장님 가게의 분류 기준별 제품 개수 조회")
-    class findTotalProduct {
+    class getTotalProductOthers {
         @Test
         @DisplayName("사장님 가게의 분류 기준별 제품 개수 조회에 성공한다")
         void success() throws IOException {
-            User user = userRepository.findByLoginIdAndStatus(WIZ.toUser().getLoginId(), Status.NORMAL).orElseThrow();
-            User manager = userRepository.findByLoginIdAndStatus(ANNE.toUser().getLoginId(), Status.NORMAL).orElseThrow();
-
-            List<GetTotalProductResponse> getTotalProductResponseList =
-                    businessProductService.getTotalProductOthers(user.getId(), manager.getId(), products[0].getStoreCondition().getValue());
+            // when - then
+            List<GetTotalProductResponse> getTotalProductResponseList = businessProductService.getTotalProductOthers(
+                    supervisor.getId(), manager.getId(), StoreCondition.ROOM.getValue());
 
             assertAll(
                     () -> assertThat(getTotalProductResponseList.get(0).name()).isEqualTo("Total"),
-                    () -> assertThat(getTotalProductResponseList.get(0).total()).isEqualTo(15),
+                    () -> assertThat(getTotalProductResponseList.get(0).total()).isEqualTo(16),
                     () -> assertThat(getTotalProductResponseList.get(1).name()).isEqualTo("Pass"),
                     () -> assertThat(getTotalProductResponseList.get(1).total()).isEqualTo(2),
                     () -> assertThat(getTotalProductResponseList.get(2).name()).isEqualTo("Close"),
                     () -> assertThat(getTotalProductResponseList.get(2).total()).isEqualTo(5),
                     () -> assertThat(getTotalProductResponseList.get(3).name()).isEqualTo("Lack"),
-                    () -> assertThat(getTotalProductResponseList.get(3).total()).isEqualTo(4)
+                    () -> assertThat(getTotalProductResponseList.get(3).total()).isEqualTo(5)
             );
         }
     }
 
     @Nested
     @DisplayName("사장님 가게의 카테고리별 제품 목록 조회")
-    class findListOfAllProduct {
+    class getListOfSearchProductOthers {
         /*
         @Test
         @DisplayName("잘못된 카테고리명이 입력되면 사장님 가게의 카테고리별 제품 목록 조회에 실패한다")

--- a/src/test/java/umc/stockoneqback/business/service/BusinessServiceTest.java
+++ b/src/test/java/umc/stockoneqback/business/service/BusinessServiceTest.java
@@ -8,10 +8,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import umc.stockoneqback.business.domain.Business;
 import umc.stockoneqback.business.exception.BusinessErrorCode;
 import umc.stockoneqback.common.ServiceTest;
+import umc.stockoneqback.fixture.StoreFixture;
 import umc.stockoneqback.global.base.RelationStatus;
 import umc.stockoneqback.global.exception.BaseException;
 import umc.stockoneqback.role.domain.company.Company;
-import umc.stockoneqback.role.domain.store.Store;
 import umc.stockoneqback.user.domain.User;
 import umc.stockoneqback.user.service.UserFindService;
 import umc.stockoneqback.user.service.UserService;
@@ -40,11 +40,12 @@ class BusinessServiceTest extends ServiceTest {
 
     @BeforeEach
     void setUp() {
-        Long storeId = storeRepository.save(createStore("스타벅스 - 광화문점", "카페", "ABC123", "서울시 종로구")).getId();
-        Long companyId = companyRepository.save(createCompany("A 납품업체", "과일", "ABC123")).getId();
-
-        managerId = userService.saveManager(SAEWOO.toUser(), storeId);
+        companyRepository.save(createCompany("A 납품업체", "과일", "ABC123"));
         supervisorId = userService.saveSupervisor(ANNE.toUser(), "A 납품업체", "ABC123");
+
+        managerId = userService.saveManager(SAEWOO.toUser());
+        Long storeId = storeRepository.save(StoreFixture.Z_SIHEUNG.toStore()).getId();
+        storeRepository.updateManagerIdById(storeId, managerId);
     }
 
     @Nested
@@ -161,15 +162,6 @@ class BusinessServiceTest extends ServiceTest {
 
         // then
         assertThat(businessRepository.findById(business.getId()).isEmpty()).isTrue();
-    }
-
-    private Store createStore(String name, String sector, String code, String address) {
-        return Store.builder()
-                .name(name)
-                .sector(sector)
-                .code(code)
-                .address(address)
-                .build();
     }
 
     private Company createCompany(String name, String sector, String code) {

--- a/src/test/java/umc/stockoneqback/friend/service/FriendServiceTest.java
+++ b/src/test/java/umc/stockoneqback/friend/service/FriendServiceTest.java
@@ -6,21 +6,16 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import umc.stockoneqback.common.ServiceTest;
-import umc.stockoneqback.fixture.StoreFixture;
 import umc.stockoneqback.friend.domain.Friend;
 import umc.stockoneqback.friend.exception.FriendErrorCode;
 import umc.stockoneqback.global.base.RelationStatus;
 import umc.stockoneqback.global.exception.BaseException;
-import umc.stockoneqback.role.domain.company.Company;
-import umc.stockoneqback.role.domain.store.Store;
 import umc.stockoneqback.user.domain.User;
 import umc.stockoneqback.user.service.UserFindService;
-import umc.stockoneqback.user.service.UserService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static umc.stockoneqback.fixture.StoreFixture.*;
 import static umc.stockoneqback.fixture.UserFixture.ANNE;
 import static umc.stockoneqback.fixture.UserFixture.UNKNOWN;
 

--- a/src/test/java/umc/stockoneqback/friend/service/FriendServiceTest.java
+++ b/src/test/java/umc/stockoneqback/friend/service/FriendServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import umc.stockoneqback.common.ServiceTest;
+import umc.stockoneqback.fixture.StoreFixture;
 import umc.stockoneqback.friend.domain.Friend;
 import umc.stockoneqback.friend.exception.FriendErrorCode;
 import umc.stockoneqback.global.base.RelationStatus;
@@ -19,16 +20,14 @@ import umc.stockoneqback.user.service.UserService;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static umc.stockoneqback.fixture.StoreFixture.*;
 import static umc.stockoneqback.fixture.UserFixture.ANNE;
 import static umc.stockoneqback.fixture.UserFixture.UNKNOWN;
 
 @DisplayName("Friend [Service Layer] -> FriendService 테스트")
 class FriendServiceTest extends ServiceTest {
     @Autowired
-    protected FriendService friendService;
-
-    @Autowired
-    private UserService userService;
+    private FriendService friendService;
 
     @Autowired
     private UserFindService userFindService;
@@ -38,11 +37,8 @@ class FriendServiceTest extends ServiceTest {
 
     @BeforeEach
     void setUp() {
-        Long storeId1 = storeRepository.save(createStore("스타벅스 - 광화문점", "카페", "ABC123", "서울시 종로구")).getId();
-        Long storeId2 = storeRepository.save(createStore("스타벅스 - 시청점", "카페", "ABCD1234", "서울시 종로구")).getId();
-
-        senderId = userService.saveManager(ANNE.toUser(), storeId1);
-        receiverId = userService.saveManager(UNKNOWN.toUser(), storeId2);
+        senderId = userRepository.save(ANNE.toUser()).getId();
+        receiverId = userRepository.save(UNKNOWN.toUser()).getId();
     }
 
     @Nested
@@ -280,22 +276,5 @@ class FriendServiceTest extends ServiceTest {
 
         // then
         assertThat(friendRepository.findById(senderId).isEmpty()).isTrue();
-    }
-
-    private Store createStore(String name, String sector, String code, String address) {
-        return Store.builder()
-                .name(name)
-                .sector(sector)
-                .code(code)
-                .address(address)
-                .build();
-    }
-
-    private Company createCompany(String name, String sector, String code) {
-        return Company.builder()
-                .name(name)
-                .sector(sector)
-                .code(code)
-                .build();
     }
 }

--- a/src/test/java/umc/stockoneqback/role/domain/store/PartTimerTest.java
+++ b/src/test/java/umc/stockoneqback/role/domain/store/PartTimerTest.java
@@ -3,14 +3,12 @@ package umc.stockoneqback.role.domain.store;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import umc.stockoneqback.user.domain.Email;
-import umc.stockoneqback.user.domain.Password;
 import umc.stockoneqback.user.domain.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static umc.stockoneqback.fixture.StoreFixture.A_PASTA;
 import static umc.stockoneqback.fixture.UserFixture.SAEWOO;
-import static umc.stockoneqback.global.utils.PasswordEncoderUtils.ENCODER;
 
 @DisplayName("PartTimer 도메인 테스트")
 class PartTimerTest {
@@ -19,8 +17,8 @@ class PartTimerTest {
 
     @BeforeEach
     void setUp() {
-        store = Store.createStore("스타벅스 - 광화문점", "카페", "서울시 중구");
-        user = User.createUser(Email.from(SAEWOO.getEmail()), SAEWOO.getLoginId(), Password.encrypt(SAEWOO.getPassword(), ENCODER), SAEWOO.getName(), SAEWOO.getBirth(), SAEWOO.getPhoneNumber(), SAEWOO.getRole());
+        store = A_PASTA.toStore();
+        user = SAEWOO.toUser();
     }
 
     @Test

--- a/src/test/java/umc/stockoneqback/role/domain/store/PartTimersTest.java
+++ b/src/test/java/umc/stockoneqback/role/domain/store/PartTimersTest.java
@@ -3,27 +3,27 @@ package umc.stockoneqback.role.domain.store;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import umc.stockoneqback.user.domain.Email;
-import umc.stockoneqback.user.domain.Password;
+import umc.stockoneqback.fixture.StoreFixture;
 import umc.stockoneqback.user.domain.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static umc.stockoneqback.fixture.UserFixture.ANNE;
+import static umc.stockoneqback.fixture.UserFixture.BOB;
 import static umc.stockoneqback.fixture.UserFixture.SAEWOO;
-import static umc.stockoneqback.global.utils.PasswordEncoderUtils.ENCODER;
 
 @DisplayName("PartTimers 도메인 테스트")
 class PartTimersTest {
     private Store store;
-    private User user1;
-    private User user2;
+
+    private User partTimer1;
+    private User partTimer2;
 
     @BeforeEach
     void setUp() {
-        store = Store.createStore("스타벅스 - 광화문점", "카페", "서울시 중구");
-        user1 = User.createUser(Email.from(SAEWOO.getEmail()), SAEWOO.getLoginId(), Password.encrypt(SAEWOO.getPassword(), ENCODER), SAEWOO.getName(), SAEWOO.getBirth(), SAEWOO.getPhoneNumber(), SAEWOO.getRole());
-        user2 = User.createUser(Email.from(ANNE.getEmail()), ANNE.getLoginId(), Password.encrypt(ANNE.getPassword(), ENCODER), ANNE.getName(), ANNE.getBirth(), ANNE.getPhoneNumber(), ANNE.getRole());
+        partTimer1 = SAEWOO.toUser();
+        partTimer2 = BOB.toUser();
+
+        store = StoreFixture.A_PASTA.toStore();
     }
 
     @Test
@@ -33,15 +33,15 @@ class PartTimersTest {
         PartTimers partTimers = PartTimers.createPartTimers();
 
         // when
-        partTimers.addPartTimer(PartTimer.createPartTimer(store, user1));
-        partTimers.addPartTimer(PartTimer.createPartTimer(store, user2));
+        partTimers.addPartTimer(PartTimer.createPartTimer(store, partTimer1));
+        partTimers.addPartTimer(PartTimer.createPartTimer(store, partTimer2));
 
         // then
         assertAll(
                 () -> assertThat(partTimers.getPartTimers()).hasSize(2),
                 () -> assertThat(partTimers.getPartTimers())
                         .map(PartTimer::getPartTimer)
-                        .contains(user1, user2)
+                        .contains(partTimer1, partTimer2)
         );
     }
 
@@ -50,8 +50,8 @@ class PartTimersTest {
     void deletePartTimer() {
         // given
         PartTimers partTimers = PartTimers.createPartTimers();
-        PartTimer partTimer1 = PartTimer.createPartTimer(store, user1);
-        PartTimer partTimer2 = PartTimer.createPartTimer(store, user2);
+        PartTimer partTimer1 = PartTimer.createPartTimer(store, this.partTimer1);
+        PartTimer partTimer2 = PartTimer.createPartTimer(store, this.partTimer2);
         partTimers.addPartTimer(partTimer1);
         partTimers.addPartTimer(partTimer2);
 

--- a/src/test/java/umc/stockoneqback/role/domain/store/StoreTest.java
+++ b/src/test/java/umc/stockoneqback/role/domain/store/StoreTest.java
@@ -7,6 +7,7 @@ import umc.stockoneqback.user.domain.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static umc.stockoneqback.fixture.StoreFixture.D_PIZZA;
 import static umc.stockoneqback.fixture.UserFixture.*;
 
 @DisplayName("Store 도메인 테스트")
@@ -15,49 +16,52 @@ class StoreTest {
     @DisplayName("Store 생성에 성공한다")
     void createStore() {
         // when
-        Store store = Store.createStore("스타벅스 - 광화문점", "카페", "서울시 중구");
+        User manager = ANNE.toUser();
+        Store store = Store.createStore(D_PIZZA.getName(), D_PIZZA.getSector(), D_PIZZA.getAddress(), manager);
 
         // then
         assertAll(
-                () -> assertThat(store.getName()).isEqualTo("스타벅스 - 광화문점"),
-                () -> assertThat(store.getSector()).isEqualTo("카페"),
-                () -> assertThat(store.getAddress()).isEqualTo("서울시 중구"),
-                () -> assertThat(store.getManager()).isNull(),
+                () -> assertThat(store.getName()).isEqualTo(D_PIZZA.getName()),
+                () -> assertThat(store.getSector()).isEqualTo(D_PIZZA.getSector()),
+                () -> assertThat(store.getAddress()).isEqualTo(D_PIZZA.getAddress()),
+                () -> assertThat(store.getManager()).isEqualTo(manager),
                 () -> assertThat(store.getPartTimers().getPartTimers()).isEmpty(),
                 () -> assertThat(store.getStatus()).isEqualTo(Status.NORMAL)
         );
     }
 
     @Test
-    @DisplayName("Store Manager 등록에 성공한다")
+    @DisplayName("Store Manager 수정에 성공한다")
     void updateStoreManager() {
         // given
-        Store store = Store.createStore("스타벅스 - 광화문점", "카페", "서울시 중구");
-        User manager = SAEWOO.toUser();
+        User manager = ANNE.toUser();
+        Store store = Store.createStore(D_PIZZA.getName(), D_PIZZA.getSector(), D_PIZZA.getAddress(), manager);
 
         // when
-        store.updateManager(manager);
+        User newManager = MIKE.toUser();
+        store.updateManager(newManager);
 
         // then
-        assertThat(store.getManager()).isEqualTo(manager);
+        assertThat(store.getManager()).isEqualTo(newManager);
     }
 
     @Test
     @DisplayName("Store PartTimer 등록에 성공한다")
     void updateStorePartTimers() {
         // given
-        Store store = Store.createStore("스타벅스 - 광화문점", "카페", "서울시 중구");
+        User manager = ANNE.toUser();
+        Store store = Store.createStore(D_PIZZA.getName(), D_PIZZA.getSector(), D_PIZZA.getAddress(), manager);
 
         // when
         User user1 = SAEWOO.toUser();
-        User user2 = ANNE.toUser();
+        User user2 = BOB.toUser();
         store.updatePartTimer(user1);
         store.updatePartTimer(user2);
 
         assertAll(
                 () -> assertThat(store.getPartTimers().getPartTimers().size()).isEqualTo(2),
                 () -> assertThat(store.getPartTimers().getPartTimers().get(0).getPartTimer().getName()).contains(SAEWOO.getName()),
-                () -> assertThat(store.getPartTimers().getPartTimers().get(1).getPartTimer().getName()).contains(ANNE.getName())
+                () -> assertThat(store.getPartTimers().getPartTimers().get(1).getPartTimer().getName()).contains(BOB.getName())
         );
     }
 
@@ -65,11 +69,15 @@ class StoreTest {
     @DisplayName("Store PartTimer 삭제에 성공한다")
     void deleteStorePartTimers() {
         // given
-        Store store = Store.createStore("스타벅스 - 광화문점", "카페", "서울시 중구");
+        User manager = ANNE.toUser();
+        Store store = Store.createStore(D_PIZZA.getName(), D_PIZZA.getSector(), D_PIZZA.getAddress(), manager);
+
         User user1 = SAEWOO.toUser();
         User user2 = WONI.toUser();
+
         PartTimer partTimer1 = PartTimer.createPartTimer(store, user1);
         PartTimer partTimer2 = PartTimer.createPartTimer(store, user2);
+
         store.updatePartTimer(partTimer1);
         store.updatePartTimer(partTimer2);
 
@@ -87,9 +95,8 @@ class StoreTest {
     @DisplayName("Store Manager 삭제에 성공한다")
     void deleteStoreManager() {
         // given
-        Store store = Store.createStore("스타벅스 - 광화문점", "카페", "서울시 중구");
-        User user = ANNE.toUser();
-        store.updateManager(user);
+        User manager = ANNE.toUser();
+        Store store = Store.createStore(D_PIZZA.getName(), D_PIZZA.getSector(), D_PIZZA.getAddress(), manager);
 
         // when
         store.deleteManager();

--- a/src/test/java/umc/stockoneqback/role/service/StoreServiceTest.java
+++ b/src/test/java/umc/stockoneqback/role/service/StoreServiceTest.java
@@ -1,5 +1,6 @@
 package umc.stockoneqback.role.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,15 +17,25 @@ import umc.stockoneqback.user.service.UserService;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static umc.stockoneqback.fixture.UserFixture.ANNE;
-import static umc.stockoneqback.fixture.UserFixture.SAEWOO;
+import static umc.stockoneqback.fixture.StoreFixture.*;
+import static umc.stockoneqback.fixture.UserFixture.*;
 
 @DisplayName("Store [Service Layer] -> StoreService 테스트")
 class StoreServiceTest extends ServiceTest {
     @Autowired
-    private UserService userService;
-    @Autowired
     private StoreService storeService;
+
+    @Autowired
+    private UserService userService;
+
+    private static User manager1;
+    private static User manager2;
+
+    @BeforeEach
+    void setup() {
+        manager1 = userRepository.save(SOPHIA.toUser());
+        manager2 = userRepository.save(ELLA.toUser());
+    }
 
     @Nested
     @DisplayName("가게 생성")
@@ -33,10 +44,10 @@ class StoreServiceTest extends ServiceTest {
         @DisplayName("이미 있는 가게 이름이면 가게 생성에 실패한다")
         void throwExceptionByAlreadyExistStore() {
             // given
-            storeService.save("스타벅스 - 광화문점", "카페", "서울시 종로구");
+            storeService.save("스타벅스 - 광화문점", "카페", "서울시 종로구", manager1.getId());
 
             // when - then
-            assertThatThrownBy(() -> storeService.save("스타벅스 - 광화문점", "카페", "서울시 종로구"))
+            assertThatThrownBy(() -> storeService.save("스타벅스 - 광화문점", "카페", "서울시 종로구", manager1.getId()))
                     .isInstanceOf(BaseException.class)
                     .hasMessage(StoreErrorCode.ALREADY_EXIST_STORE.getMessage());
         }
@@ -45,8 +56,8 @@ class StoreServiceTest extends ServiceTest {
         @DisplayName("가게 생성에 성공한다")
         void success() {
             // when
-            Long storeId1 = storeService.save("스타벅스 - 광화문점", "카페", "서울시 종로구");
-            Long storeId2 = storeService.save("스타벅스 - 을지로점", "카페", "서울시 중구");
+            Long storeId1 = storeService.save("스타벅스 - 광화문점", "카페", "서울시 종로구", manager1.getId());
+            Long storeId2 = storeService.save("스타벅스 - 을지로점", "카페", "서울시 중구", manager2.getId());
 
             // then
             Store findStore1 = storeRepository.findById(storeId1).orElseThrow();
@@ -68,9 +79,9 @@ class StoreServiceTest extends ServiceTest {
     @DisplayName("가게 ID로 가게를 조회한다")
     void findById() {
         // given
-        Store store1 = createStore("스타벅스 - 광화문점", "카페", "ABC123", "서울시 종로구");
-        Store store2 = createStore("스타벅스 - 을지로점", "카페", "ABC123", "서울시 중구");
-        Store store3 = createStore("스타벅스 - 신촌점", "카페", "ABC123", "서울시 서대문구");
+        Store store1 = A_PASTA.toStore();
+        Store store2 = B_CHICKEN.toStore();
+        Store store3 = D_PIZZA.toStore();
 
         Long storeId1 = storeRepository.save(store1).getId();
         Long storeId2 = storeRepository.save(store2).getId();
@@ -103,18 +114,14 @@ class StoreServiceTest extends ServiceTest {
     @DisplayName("가게 이름으로 가게를 조회한다")
     void findByName() {
         // given
-        Store store1 = createStore("스타벅스 - 광화문점", "카페", "ABC123", "서울시 종로구");
-        Store store2 = createStore("스타벅스 - 을지로점", "카페", "ABC123", "서울시 중구");
-        Store store3 = createStore("스타벅스 - 신촌점", "카페", "ABC123", "서울시 서대문구");
-
-        storeRepository.save(store1);
-        storeRepository.save(store2);
-        storeRepository.save(store3);
+        Store store1 = storeRepository.save(A_PASTA.toStore());
+        Store store2 = storeRepository.save(B_CHICKEN.toStore());
+        Store store3 = storeRepository.save(D_PIZZA.toStore());
 
         // when
-        Store findStore1 = storeService.findByName("스타벅스 - 광화문점");
-        Store findStore2 = storeService.findByName("스타벅스 - 을지로점");
-        Store findStore3 = storeService.findByName("스타벅스 - 신촌점");
+        Store findStore1 = storeService.findByName(A_PASTA.getName());
+        Store findStore2 = storeService.findByName(B_CHICKEN.getName());
+        Store findStore3 = storeService.findByName(D_PIZZA.getName());
 
         // then
         assertAll(
@@ -123,13 +130,13 @@ class StoreServiceTest extends ServiceTest {
                 () -> assertThat(findStore3).isEqualTo(store3)
         );
 
-        assertThatThrownBy(() -> storeService.findByName("투썸플레이스 - 광화문점"))
+        assertThatThrownBy(() -> storeService.findByName(A_PASTA.getName() + "FAKE"))
                 .isInstanceOf(BaseException.class)
                 .hasMessage(StoreErrorCode.STORE_NOT_FOUND.getMessage());
-        assertThatThrownBy(() -> storeService.findByName("투썸플레이스 - 을지로점"))
+        assertThatThrownBy(() -> storeService.findByName(B_CHICKEN.getName() + "FAKE"))
                 .isInstanceOf(BaseException.class)
                 .hasMessage(StoreErrorCode.STORE_NOT_FOUND.getMessage());
-        assertThatThrownBy(() -> storeService.findByName("투썸플레이스 - 신촌점"))
+        assertThatThrownBy(() -> storeService.findByName(D_PIZZA.getName() + "FAKE"))
                 .isInstanceOf(BaseException.class)
                 .hasMessage(StoreErrorCode.STORE_NOT_FOUND.getMessage());
     }
@@ -138,8 +145,7 @@ class StoreServiceTest extends ServiceTest {
     @DisplayName("가게 사장님 삭제에 성공한다")
     void deleteManager() {
         // given
-        Long storeId = storeService.save("스타벅스 - 광화문점", "카페", "서울시 종로구");
-        userService.saveManager(ANNE.toUser(), storeId);
+        Long storeId = storeService.save("스타벅스 - 광화문점", "카페", "서울시 종로구", manager1.getId());
 
         // when
         Store store = storeRepository.findById(storeId).orElseThrow();
@@ -153,26 +159,15 @@ class StoreServiceTest extends ServiceTest {
     @DisplayName("가게 아르바이생님 삭제에 성공한다")
     void deletePartTimersByPartTimer() {
         // given
-        Long storeId = storeService.save("스타벅스 - 광화문점", "카페", "서울시 종로구");
-        Store store = storeRepository.findById(storeId).orElseThrow();
-
+        Store store = storeRepository.save(Store.createStore(A_PASTA.getName(), A_PASTA.getSector(), A_PASTA.getAddress(), manager1));
         Long userId = userService.savePartTimer(SAEWOO.toUser(), store.getName(), store.getCode());
-        User user = userRepository.findById(userId).orElseThrow();
-        PartTimer partTimer = partTimerRepository.findByPartTimer(user).orElseThrow();
 
         // when
+        User user = userRepository.findById(userId).orElseThrow();
+        PartTimer partTimer = partTimerRepository.findByPartTimer(user).orElseThrow();
         storeService.deletePartTimer(store, partTimer);
 
         // then
         assertThat(store.getPartTimers().getPartTimers().contains(partTimer)).isFalse();
-    }
-
-    private Store createStore(String name, String sector, String code, String address) {
-        return Store.builder()
-                .name(name)
-                .sector(sector)
-                .code(code)
-                .address(address)
-                .build();
     }
 }

--- a/src/test/java/umc/stockoneqback/user/controller/UserApiControllerTest.java
+++ b/src/test/java/umc/stockoneqback/user/controller/UserApiControllerTest.java
@@ -45,7 +45,7 @@ class UserApiControllerTest extends ControllerTest {
             // given
             doThrow(BaseException.type(StoreErrorCode.ALREADY_EXIST_STORE))
                     .when(storeService)
-                    .save(any(), any(), any());
+                    .save(any(), any(), any(), anyLong());
 
             // when
             final SignUpManagerRequest request = createSignUpManagerRequest();
@@ -98,10 +98,10 @@ class UserApiControllerTest extends ControllerTest {
             // given
             doReturn(STORE_ID)
                     .when(storeService)
-                    .save(anyString(), anyString(), anyString());
+                    .save(anyString(), anyString(), anyString(), anyLong());
             doThrow(BaseException.type(UserErrorCode.DUPLICATE_LOGIN_ID))
                     .when(userService)
-                    .saveManager(any(), anyLong());
+                    .saveManager(any());
 
             // when
             final SignUpManagerRequest request = createSignUpManagerRequest();
@@ -153,10 +153,10 @@ class UserApiControllerTest extends ControllerTest {
             // given
             doReturn(STORE_ID)
                     .when(storeService)
-                    .save(anyString(), anyString(), anyString());
+                    .save(anyString(), anyString(), anyString(), anyLong());
             doThrow(BaseException.type(UserErrorCode.DUPLICATE_LOGIN_ID))
                     .when(userService)
-                    .saveManager(any(), anyLong());
+                    .saveManager(any());
 
             // when
             final SignUpManagerRequest request = createSignUpManagerRequest();
@@ -209,10 +209,10 @@ class UserApiControllerTest extends ControllerTest {
             // given
             doReturn(STORE_ID)
                     .when(storeService)
-                    .save(anyString(), anyString(), anyString());
+                    .save(anyString(), anyString(), anyString(), anyLong());
             doReturn(USER_ID)
                     .when(userService)
-                    .saveManager(any(), anyLong());
+                    .saveManager(any());
 
             // when
             final SignUpManagerRequest request = createSignUpManagerRequest();

--- a/src/test/java/umc/stockoneqback/user/service/UserServiceTest.java
+++ b/src/test/java/umc/stockoneqback/user/service/UserServiceTest.java
@@ -143,17 +143,6 @@ class UserServiceTest extends ServiceTest {
         }
     }
 
-    @Nested
-    @DisplayName("로그인 아이디 찾기")
-    class findLoginId {
-        @Test
-        @DisplayName("요청된 정보와 일치하는 사용자를 찾을 수 없으면 아이디 찾기에 실패한다")
-        void throwExceptionByDuplicateLoginId() {
-
-        }
-
-    }
-
     @Test
     @DisplayName("사용자 관련 정보를 삭제하고 사용자 개인정보의 상태를 변경한다")
     void withdrawUser() {

--- a/src/test/java/umc/stockoneqback/user/service/UserServiceTest.java
+++ b/src/test/java/umc/stockoneqback/user/service/UserServiceTest.java
@@ -20,7 +20,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static umc.stockoneqback.fixture.UserFixture.SAEWOO;
+import static umc.stockoneqback.fixture.StoreFixture.D_PIZZA;
+import static umc.stockoneqback.fixture.UserFixture.*;
+import static umc.stockoneqback.global.utils.PasswordEncoderUtils.ENCODER;
 
 @DisplayName("User [Service Layer] -> UserService 테스트")
 class UserServiceTest extends ServiceTest {
@@ -30,30 +32,35 @@ class UserServiceTest extends ServiceTest {
     @Autowired
     private AuthService authService;
 
-    private Store store;
-    private Company company;
-
-    @BeforeEach
-    void setUp() {
-        store = storeRepository.save(createStore("스타벅스 - 광화문점", "카페", "ABC123", "서울시 종로구"));
-        company = companyRepository.save(createCompany("A 납품업체", "과일", "ABC123"));
-    }
-
     @Test
     @DisplayName("가게 사장님 등록에 성공한다")
     void saveManager() {
         // when
-        User manager = SAEWOO.toUser();
-        userService.saveManager(manager, store.getId());
+        Long managerId = userService.saveManager(ELLA.toUser());
 
         // then
-        Store findStore = storeRepository.findById(store.getId()).orElseThrow();
-        assertThat(findStore.getManager()).isEqualTo(manager);
+        User findManager = userRepository.findById(managerId).orElseThrow();
+        assertAll(
+                () -> assertThat(findManager.getName()).isEqualTo(ELLA.getName()),
+                () -> assertThat(findManager.getLoginId()).isEqualTo(ELLA.getLoginId()),
+                () -> assertThat(findManager.getPassword().isSamePassword(ELLA.getPassword(), ENCODER)).isTrue(),
+                () -> assertThat(findManager.getBirth()).isEqualTo(ELLA.getBirth()),
+                () -> assertThat(findManager.getPhoneNumber()).isEqualTo(ELLA.getPhoneNumber()),
+                () -> assertThat(findManager.getRole()).isEqualTo(ELLA.getRole())
+        );
     }
 
     @Nested
     @DisplayName("아르바이트생 등록")
     class savePartTimer {
+        private Store store;
+
+        @BeforeEach
+        void setUp() {
+            User manager = userRepository.save(ELLA.toUser());
+            store = storeRepository.save(Store.createStore(D_PIZZA.getName(), D_PIZZA.getSector(), D_PIZZA.getAddress(), manager));
+        }
+
         @Test
         @DisplayName("가게 코드가 일치하지 않으면 아르바이트생 등록에 실패한다")
         void throwExceptionByInvalidStoreCode() {
@@ -61,7 +68,7 @@ class UserServiceTest extends ServiceTest {
             User partTimer = SAEWOO.toUser();
 
             // when - then
-            assertThatThrownBy(() -> userService.savePartTimer(partTimer, "스타벅스 - 광화문점", "ABC456"))
+            assertThatThrownBy(() -> userService.savePartTimer(partTimer, store.getName(), store.getCode() + "FAKE"))
                     .isInstanceOf(BaseException.class)
                     .hasMessage(UserErrorCode.INVALID_STORE_CODE.getMessage());
         }
@@ -70,13 +77,20 @@ class UserServiceTest extends ServiceTest {
         @DisplayName("아르바이트생 등록에 성공한다")
         void success() {
             // when
-            Long savedUserId = userService.savePartTimer(SAEWOO.toUser(), store.getName(), store.getCode());
+            Long savedPartTimerId = userService.savePartTimer(SAEWOO.toUser(), store.getName(), store.getCode());
 
             // then
+            User findPartTimer = userRepository.findById(savedPartTimerId).orElseThrow();
             Store findStore = storeRepository.findById(store.getId()).orElseThrow();
             assertAll(
+                    () -> assertThat(findPartTimer.getName()).isEqualTo(SAEWOO.getName()),
+                    () -> assertThat(findPartTimer.getLoginId()).isEqualTo(SAEWOO.getLoginId()),
+                    () -> assertThat(findPartTimer.getPassword().isSamePassword(SAEWOO.getPassword(), ENCODER)).isTrue(),
+                    () -> assertThat(findPartTimer.getBirth()).isEqualTo(SAEWOO.getBirth()),
+                    () -> assertThat(findPartTimer.getPhoneNumber()).isEqualTo(SAEWOO.getPhoneNumber()),
+                    () -> assertThat(findPartTimer.getRole()).isEqualTo(SAEWOO.getRole()),
                     () -> assertThat(findStore.getPartTimers().getPartTimers().size()).isEqualTo(1),
-                    () -> assertThat(findStore.getPartTimers().getPartTimers().get(0).getPartTimer().getId()).isEqualTo(savedUserId)
+                    () -> assertThat(findStore.getPartTimers().getPartTimers().get(0).getPartTimer().getId()).isEqualTo(savedPartTimerId)
             );
         }
     }
@@ -84,6 +98,13 @@ class UserServiceTest extends ServiceTest {
     @Nested
     @DisplayName("슈퍼바이저 등록")
     class saveSupervisor {
+        private Company company;
+
+        @BeforeEach
+        void setUp() {
+            company = companyRepository.save(createCompany("A 납품업체", "과일", "ABC123"));
+        }
+
         @Test
         @DisplayName("회사 코드가 일치하지 않으면 슈퍼바이저 등록에 실패한다")
         void throwExceptionByInvalidCompanyCode() {
@@ -100,7 +121,7 @@ class UserServiceTest extends ServiceTest {
         @DisplayName("슈퍼바이저 등록에 성공한다")
         void success() {
             // given
-            User supervisor = SAEWOO.toUser();
+            User supervisor = JACK.toUser();
 
             // when
             Long saveSupervisorId = userService.saveSupervisor(supervisor, company.getName(), company.getCode());
@@ -109,6 +130,12 @@ class UserServiceTest extends ServiceTest {
             User findSupervisor = userRepository.findById(saveSupervisorId).orElseThrow();
             Company findCompany = companyRepository.findById(company.getId()).orElseThrow();
             assertAll(
+                    () -> assertThat(findSupervisor.getName()).isEqualTo(JACK.getName()),
+                    () -> assertThat(findSupervisor.getLoginId()).isEqualTo(JACK.getLoginId()),
+                    () -> assertThat(findSupervisor.getPassword().isSamePassword(JACK.getPassword(), ENCODER)).isTrue(),
+                    () -> assertThat(findSupervisor.getBirth()).isEqualTo(JACK.getBirth()),
+                    () -> assertThat(findSupervisor.getPhoneNumber()).isEqualTo(JACK.getPhoneNumber()),
+                    () -> assertThat(findSupervisor.getRole()).isEqualTo(JACK.getRole()),
                     () -> assertThat(findCompany.getEmployees().size()).isEqualTo(1),
                     () -> assertThat(findCompany.getEmployees()).contains(findSupervisor),
                     () -> assertThat(findSupervisor.getCompany()).isEqualTo(findCompany)
@@ -159,15 +186,6 @@ class UserServiceTest extends ServiceTest {
         // then
         Optional<User> findUser = userRepository.findById(user.getId());
         assertThat(findUser.isEmpty()).isTrue();
-    }
-
-    private Store createStore(String name, String sector, String code, String address) {
-        return Store.builder()
-                .name(name)
-                .sector(sector)
-                .code(code)
-                .address(address)
-                .build();
     }
 
     private Company createCompany(String name, String sector, String code) {


### PR DESCRIPTION
## Summary 📌
- 사장님 회원가입시 User와 Store가 DB에 저장되는 순서를 바꾼다

## Describe your changes 📝
- UserService의 사장님 회원가입 로직 변경
- StoreService의 가게 저장 로직 변경
- 그에 따른 각종 테스트 코드 수정
- admin, auth, board 패키지 테스트 코드 리팩토링

## Check list ✅
- [X] I write PR according to the form
- [X] All tests are passed
- [X] Program works normally
- [X] I set proper PR labels
- [X] I remove any redundant codes

## Issue numbers and link 🚪
Closes #168 
